### PR TITLE
Fix geSuiteBans (please double check, even tho we spent some time testing it...)

### DIFF
--- a/src/main/java/net/cubespace/geSuit/Utilities.java
+++ b/src/main/java/net/cubespace/geSuit/Utilities.java
@@ -4,7 +4,9 @@ import com.google.common.net.InetAddresses;
 import com.mojang.api.profiles.HttpProfileRepository;
 import com.mojang.api.profiles.Profile;
 import com.mojang.api.profiles.ProfileCriteria;
+import net.cubespace.geSuit.tasks.DatabaseUpdateRowUUID;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.ProxyServer;
 
 public class Utilities {
     private static final HttpProfileRepository profileRepository = new HttpProfileRepository();
@@ -25,5 +27,10 @@ public class Utilities {
         } else {
             return null;
         }
+    }
+    
+    public static void databaseUpdateRowUUID(int id, String playerName)
+    {
+        ProxyServer.getInstance().getScheduler().runAsync(geSuit.instance, new DatabaseUpdateRowUUID(id, playerName));
     }
 }

--- a/src/main/java/net/cubespace/geSuit/commands/BanCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/BanCommand.java
@@ -3,7 +3,6 @@ package net.cubespace.geSuit.commands;
 import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.managers.BansManager;
 import net.cubespace.geSuit.managers.ConfigManager;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 
@@ -25,11 +24,11 @@ public class BanCommand extends Command
             return;
         }
         if (args.length == 0) {
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.BUNGEE_COMMAND_BAN_USAGE));
+            sender.sendMessage(Utilities.colorize(ConfigManager.messages.BUNGEE_COMMAND_BAN_USAGE));
             return;
         }
         if (!(sender.hasPermission("gesuit.ban") || sender.hasPermission("gesuit.admin"))) {
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.NO_PERMISSION));
+            sender.sendMessage(Utilities.colorize(ConfigManager.messages.NO_PERMISSION));
 
             return;
         }

--- a/src/main/java/net/cubespace/geSuit/commands/BanCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/BanCommand.java
@@ -1,0 +1,43 @@
+package net.cubespace.geSuit.commands;
+
+import net.cubespace.geSuit.Utilities;
+import net.cubespace.geSuit.managers.BansManager;
+import net.cubespace.geSuit.managers.ConfigManager;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Command;
+
+/**
+ * Command: /motd Permission needed: gesuit.motd or gesuit.admin Arguments: none What does it do: Prints out the MOTD
+ */
+public class BanCommand extends Command
+{
+
+    public BanCommand()
+    {
+        super("!ban");
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args)
+    {
+        if (!(sender instanceof CommandSender)) {
+            return;
+        }
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.BUNGEE_COMMAND_BAN_USAGE));
+            return;
+        }
+        if (!(sender.hasPermission("gesuit.ban") || sender.hasPermission("gesuit.admin"))) {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.NO_PERMISSION));
+
+            return;
+        }
+        if (Utilities.isIPAddress(args[0])) {
+            BansManager.banIP(sender.getName(), args[0], null);
+        }
+        else {
+            BansManager.banPlayer(sender.getName(), args[0], null);
+        }
+    }
+}

--- a/src/main/java/net/cubespace/geSuit/commands/BanCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/BanCommand.java
@@ -3,12 +3,11 @@ package net.cubespace.geSuit.commands;
 import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.managers.BansManager;
 import net.cubespace.geSuit.managers.ConfigManager;
+import net.cubespace.geSuit.managers.PlayerManager;
 import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 
-/**
- * Command: /motd Permission needed: gesuit.motd or gesuit.admin Arguments: none What does it do: Prints out the MOTD
- */
 public class BanCommand extends Command
 {
 
@@ -20,16 +19,11 @@ public class BanCommand extends Command
     @Override
     public void execute(CommandSender sender, String[] args)
     {
-        if (!(sender instanceof CommandSender)) {
+        if (sender instanceof ProxiedPlayer) {
             return;
         }
         if (args.length == 0) {
-            sender.sendMessage(Utilities.colorize(ConfigManager.messages.BUNGEE_COMMAND_BAN_USAGE));
-            return;
-        }
-        if (!(sender.hasPermission("gesuit.ban") || sender.hasPermission("gesuit.admin"))) {
-            sender.sendMessage(Utilities.colorize(ConfigManager.messages.NO_PERMISSION));
-
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.BUNGEE_COMMAND_BAN_USAGE);
             return;
         }
         if (Utilities.isIPAddress(args[0])) {

--- a/src/main/java/net/cubespace/geSuit/commands/MOTDCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/MOTDCommand.java
@@ -1,7 +1,7 @@
 package net.cubespace.geSuit.commands;
 
-import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.managers.ConfigManager;
+import net.cubespace.geSuit.managers.PlayerManager;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 
@@ -19,14 +19,11 @@ public class MOTDCommand extends Command {
     @Override
     public void execute(CommandSender sender, String[] args) {
         if (!(sender.hasPermission("gesuit.motd") || sender.hasPermission("gesuit.admin"))) {
-            sender.sendMessage(Utilities.colorize(ConfigManager.messages.NO_PERMISSION));
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.NO_PERMISSION);
 
             return;
         }
-
-        for (String split : ConfigManager.messages.MOTD.split("\n")) {
-            sender.sendMessage(Utilities.colorize(split));
-        }
+        PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.MOTD);
     }
 }
 

--- a/src/main/java/net/cubespace/geSuit/commands/MOTDCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/MOTDCommand.java
@@ -1,7 +1,7 @@
 package net.cubespace.geSuit.commands;
 
+import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.managers.ConfigManager;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 
@@ -19,13 +19,13 @@ public class MOTDCommand extends Command {
     @Override
     public void execute(CommandSender sender, String[] args) {
         if (!(sender.hasPermission("gesuit.motd") || sender.hasPermission("gesuit.admin"))) {
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.NO_PERMISSION));
+            sender.sendMessage(Utilities.colorize(ConfigManager.messages.NO_PERMISSION));
 
             return;
         }
 
         for (String split : ConfigManager.messages.MOTD.split("\n")) {
-            sender.sendMessage(split);
+            sender.sendMessage(Utilities.colorize(split));
         }
     }
 }

--- a/src/main/java/net/cubespace/geSuit/commands/ReloadCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/ReloadCommand.java
@@ -3,25 +3,26 @@ package net.cubespace.geSuit.commands;
 import net.cubespace.Yamler.Config.InvalidConfigurationException;
 import net.cubespace.geSuit.managers.AnnouncementManager;
 import net.cubespace.geSuit.managers.ConfigManager;
-import net.md_5.bungee.api.ChatColor;
+import net.cubespace.geSuit.managers.PlayerManager;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 
 /**
- * Command: /gsreload
- * Permission needed: gesuit.reload or gesuit.admin
- * Arguments: none
- * What does it do: Reloads every config
+ * Command: /gsreload Permission needed: gesuit.reload or gesuit.admin Arguments: none What does it do: Reloads every config
  */
-public class ReloadCommand extends Command {
-    public ReloadCommand() {
+public class ReloadCommand extends Command
+{
+
+    public ReloadCommand()
+    {
         super("gsreload");
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
+    public void execute(CommandSender sender, String[] args)
+    {
         if (!(sender.hasPermission("gesuit.reload") || sender.hasPermission("gesuit.admin"))) {
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&',ConfigManager.messages.NO_PERMISSION));
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.NO_PERMISSION);
 
             return;
         }
@@ -34,10 +35,11 @@ public class ReloadCommand extends Command {
             ConfigManager.messages.reload();
 
             AnnouncementManager.reloadAnnouncements();
-            sender.sendMessage("All Configs reloaded");
-        } catch (InvalidConfigurationException e) {
+            PlayerManager.sendMessageToTarget(sender, "All Configs reloaded");
+        }
+        catch (InvalidConfigurationException e) {
             e.printStackTrace();
-            sender.sendMessage("Could not reload. Check the logs");
+            PlayerManager.sendMessageToTarget(sender, "Could not reload. Check the logs");
         }
     }
 }

--- a/src/main/java/net/cubespace/geSuit/commands/SeenCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/SeenCommand.java
@@ -1,0 +1,36 @@
+package net.cubespace.geSuit.commands;
+
+import net.cubespace.geSuit.managers.ConfigManager;
+import net.cubespace.geSuit.managers.PlayerManager;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Command;
+
+/**
+ * Command: /seen 
+ * Permission needed: gesuit.seen or gesuit.admin 
+ * Arguments: none 
+ * What does it do: Displays <player> last online time
+ */
+public class SeenCommand extends Command
+{
+
+    public SeenCommand()
+    {
+        super("seen");
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args)
+    {
+        if (!(sender.hasPermission("gesuit.seen") || sender.hasPermission("gesuit.admin"))) {
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.NO_PERMISSION);
+
+            return;
+        }
+        if (args.length == 0) {
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.BUNGEE_COMMAND_SEEN_USAGE);
+            return;
+        }
+        PlayerManager.sendMessageToTarget(sender, PlayerManager.getLastSeeninfos(args[0]));
+    }
+}

--- a/src/main/java/net/cubespace/geSuit/commands/UnbanCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/UnbanCommand.java
@@ -1,8 +1,8 @@
 package net.cubespace.geSuit.commands;
 
+import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.managers.BansManager;
 import net.cubespace.geSuit.managers.ConfigManager;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
 
@@ -23,11 +23,11 @@ public class UnbanCommand extends Command {
             return;
         if (args.length == 0)
         {
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.BUNGEE_COMMAND_UNBAN_USAGE));
+            sender.sendMessage(Utilities.colorize(ConfigManager.messages.BUNGEE_COMMAND_UNBAN_USAGE));
             return;
         }
         if (!(sender.hasPermission("gesuit.unban") || sender.hasPermission("gesuit.admin"))) {
-            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.NO_PERMISSION));
+            sender.sendMessage(Utilities.colorize(ConfigManager.messages.NO_PERMISSION));
 
             return;
         }

--- a/src/main/java/net/cubespace/geSuit/commands/UnbanCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/UnbanCommand.java
@@ -1,39 +1,32 @@
 package net.cubespace.geSuit.commands;
 
-import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.managers.BansManager;
 import net.cubespace.geSuit.managers.ConfigManager;
+import net.cubespace.geSuit.managers.PlayerManager;
 import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Command;
 
-/**
- * Command: /motd
- * Permission needed: gesuit.motd or gesuit.admin
- * Arguments: none
- * What does it do: Prints out the MOTD
- */
-public class UnbanCommand extends Command {
-    public UnbanCommand() {
+public class UnbanCommand extends Command
+{
+
+    public UnbanCommand()
+    {
         super("!unban");
     }
 
     @Override
-    public void execute(CommandSender sender, String[] args) {
-        if (!(sender instanceof CommandSender))
-            return;
-        if (args.length == 0)
-        {
-            sender.sendMessage(Utilities.colorize(ConfigManager.messages.BUNGEE_COMMAND_UNBAN_USAGE));
+    public void execute(CommandSender sender, String[] args)
+    {
+
+        if (sender instanceof ProxiedPlayer) {
             return;
         }
-        if (!(sender.hasPermission("gesuit.unban") || sender.hasPermission("gesuit.admin"))) {
-            sender.sendMessage(Utilities.colorize(ConfigManager.messages.NO_PERMISSION));
-
+        if (args.length == 0) {
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.BUNGEE_COMMAND_UNBAN_USAGE);
             return;
         }
 
         BansManager.unbanPlayer(sender.getName(), args[0]);
     }
 }
-
-

--- a/src/main/java/net/cubespace/geSuit/commands/UnbanCommand.java
+++ b/src/main/java/net/cubespace/geSuit/commands/UnbanCommand.java
@@ -1,0 +1,39 @@
+package net.cubespace.geSuit.commands;
+
+import net.cubespace.geSuit.managers.BansManager;
+import net.cubespace.geSuit.managers.ConfigManager;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Command;
+
+/**
+ * Command: /motd
+ * Permission needed: gesuit.motd or gesuit.admin
+ * Arguments: none
+ * What does it do: Prints out the MOTD
+ */
+public class UnbanCommand extends Command {
+    public UnbanCommand() {
+        super("!unban");
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (!(sender instanceof CommandSender))
+            return;
+        if (args.length == 0)
+        {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.BUNGEE_COMMAND_UNBAN_USAGE));
+            return;
+        }
+        if (!(sender.hasPermission("gesuit.unban") || sender.hasPermission("gesuit.admin"))) {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', ConfigManager.messages.NO_PERMISSION));
+
+            return;
+        }
+
+        BansManager.unbanPlayer(sender.getName(), args[0]);
+    }
+}
+
+

--- a/src/main/java/net/cubespace/geSuit/configs/MainConfig.java
+++ b/src/main/java/net/cubespace/geSuit/configs/MainConfig.java
@@ -1,11 +1,10 @@
 package net.cubespace.geSuit.configs;
 
+import java.io.File;
 import net.cubespace.Yamler.Config.Comment;
-import net.cubespace.geSuit.geSuit;
 import net.cubespace.Yamler.Config.Config;
 import net.cubespace.geSuit.configs.SubConfig.Database;
-
-import java.io.File;
+import net.cubespace.geSuit.geSuit;
 
 public class MainConfig extends Config {
     public MainConfig() {
@@ -16,7 +15,12 @@ public class MainConfig extends Config {
     public Boolean ConvertFromBungeeSuite = false;
     public Database BungeeSuiteDatabase = new Database();
 
+    @Comment("Turn this to false if you want to use your regular /motd comand (requires restart)")
     public Boolean MOTD_Enabled = true;
+    @Comment("Turn this to false if you want to use your your regular /seen comand (requires restart)")
+    public Boolean Seen_Enabled = false;
+    
+    @Comment()
     public Boolean NewPlayerBroadcast = true;
     public Boolean BroadcastProxyConnectionMessages = true;
     public Integer PlayerDisconnectDelay = 10;

--- a/src/main/java/net/cubespace/geSuit/configs/Messages.java
+++ b/src/main/java/net/cubespace/geSuit/configs/Messages.java
@@ -1,10 +1,9 @@
 package net.cubespace.geSuit.configs;
 
-import net.cubespace.geSuit.geSuit;
+import java.io.File;
 import net.cubespace.Yamler.Config.Config;
 import net.cubespace.Yamler.Config.ConfigMode;
-
-import java.io.File;
+import net.cubespace.geSuit.geSuit;
 
 public class Messages extends Config {
     public Messages() {
@@ -68,10 +67,14 @@ public class Messages extends Config {
     public String SPAWN_UPDATED = "&2" + "Spawn point updated";
     public String SPAWN_SET = "&2" + "Spawn point set";
     // ban messages
+    public String BUNGEE_COMMAND_BAN_USAGE = "&c" + "Usage: !ban player|ip";
+    public String BUNGEE_COMMAND_UNBAN_USAGE = "&c" + "Usage: !unban player|uuid|ip";
+    public String UNKNOWN_PLAYER_STILL_BANNING = "&c" + "Player is unknown. Banning by name and &nmaybe&r&c by UUID.";
     public String KICK_PLAYER_MESSAGE = "&c" + "You have been kicked for: {message}, by {sender}";
     public String KICK_PLAYER_BROADCAST = "&c" + "{player} has been kicked for {message}, by {sender}!";
     public String PLAYER_ALREADY_BANNED = "&c" + "That player is already banned";
     public String PLAYER_NOT_BANNED = "&c" + "That player is not banned";
+    public String PLAYER_NEVER_BANNED = "&2" + "No ban history for {player} (sweet baby raptor jesus!)";
     public String IPBAN_PLAYER = "&c" + "You have been IP banned for: {message}, by {sender}";
     public String IPBAN_PLAYER_BROADCAST = "&c" + "{player} has been ip banned for: {message}, by {sender}";
     public String DEFAULT_BAN_REASON = "Breaking server rules";

--- a/src/main/java/net/cubespace/geSuit/configs/Messages.java
+++ b/src/main/java/net/cubespace/geSuit/configs/Messages.java
@@ -12,6 +12,9 @@ public class Messages extends Config {
     }
 
     public String MOTD = "&dWelcome to the server {player}!";
+    public String PLAYER_SEEN_ONLINE = "&a| Player &2{player} &ais currently online!\n&a| ip:{ip}    Server:{server}";
+    public String PLAYER_SEEN_OFFLINE = "&c| Player &4{player}&c is offline. Last seen: {seen}!\n&c| ip:{ip}";
+    public String BUNGEE_COMMAND_SEEN_USAGE = "&cUsage: /seen <player>";
     public String PLAYER_CONNECT_PROXY = "{player}&e has joined the server!";
     public String PLAYER_DISCONNECT_PROXY = "{player}&e has left the server!";
     public String PLAYER_DOES_NOT_EXIST = "&c" + "That player does not exist";

--- a/src/main/java/net/cubespace/geSuit/database/Bans.java
+++ b/src/main/java/net/cubespace/geSuit/database/Bans.java
@@ -1,5 +1,13 @@
 package net.cubespace.geSuit.database;
 
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.cubespace.Yamler.Config.InvalidConfigurationException;
 import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.Utilities;
@@ -7,75 +15,133 @@ import net.cubespace.geSuit.managers.ConfigManager;
 import net.cubespace.geSuit.managers.DatabaseManager;
 import net.cubespace.geSuit.objects.Ban;
 
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 /**
  * @author geNAZt (fabian.fassbender42@googlemail.com)
  */
-public class Bans implements IRepository {
-    public boolean isPlayerBanned(String player) {
+public class Bans implements IRepository
+{
+
+    public boolean isPlayerBanned(String player)
+    {
+        return isPlayerBanned(player, null, null);
+    }
+
+    public boolean isPlayerBanned(String player, String uuid)
+    {
+        return isPlayerBanned(player, uuid, null);
+    }
+
+    public boolean isPlayerBanned(String player, String uuid, String ip)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
 
         try {
             PreparedStatement isPlayerBanned = connectionHandler.getPreparedStatement("isPlayerBanned");
             isPlayerBanned.setString(1, player);
+            isPlayerBanned.setString(2, uuid);
+            isPlayerBanned.setString(3, ip);
 
             if (isPlayerBanned.executeQuery().next()) {
                 return true;
-            } else {
+            }
+            else {
                 return false;
             }
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
 
         return false;
     }
 
-    public void banPlayer(String display, String bannedBy, String bannedEntity, String reason, String type) {
+    public int banPlayer(String banned_playername, String bannedBy, String reason, String type)
+    {
+        return banPlayer(banned_playername, null, null, bannedBy, reason, type);
+    }
+
+    public int banPlayer(String banned_playername, String banned_uuid, String banned_ip, String bannedBy,  String reason, String type)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
 
         try {
             PreparedStatement banPlayer = connectionHandler.getPreparedStatement("banPlayer");
-            banPlayer.setString(1, display);
-            banPlayer.setString(2, bannedEntity);
-            banPlayer.setString(3, bannedBy);
-            banPlayer.setString(4, reason);
-            banPlayer.setString(5, type);
+            banPlayer.setString(1, banned_playername);
+            banPlayer.setString(2, banned_uuid);
+            banPlayer.setString(3, banned_ip);
+            banPlayer.setString(4, bannedBy);
+            banPlayer.setString(5, reason);
+            banPlayer.setString(6, type);
 
-            banPlayer.executeUpdate();
-        } catch (Exception e) {
+            return banPlayer.executeUpdate();
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
+        return -1;
     }
 
-    public void tempBanPlayer(String display, String bannedBy, String bannedEntity, String reason, String till) {
+    public void tempBanPlayer(String banned_playername, String bannedBy, String banned_uuid, String reason, String till)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
 
         try {
             PreparedStatement tempBanPlayer = connectionHandler.getPreparedStatement("tempBanPlayer");
-            tempBanPlayer.setString(1, display);
-            tempBanPlayer.setString(2, bannedEntity);
+            tempBanPlayer.setString(1, banned_playername);
+            tempBanPlayer.setString(2, banned_uuid);
             tempBanPlayer.setString(3, bannedBy);
             tempBanPlayer.setString(4, reason);
             tempBanPlayer.setString(5, till);
 
             tempBanPlayer.executeUpdate();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
     }
+    
+    public List<Ban> getBanHistory(String lookup)
+    {
+        List<Ban> bans = new ArrayList<Ban>();
+        ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
+        try {
+            PreparedStatement banInfo = connectionHandler.getPreparedStatement("banHistory");
+            banInfo.setString(1, lookup);
+            banInfo.setString(2, lookup);
+            banInfo.setString(3, lookup);
 
-    public Ban getBanInfo(String player) {
+            ResultSet res = banInfo.executeQuery();
+            while (res.next()) {
+                bans.add(new Ban(res.getInt("id"), res.getString("banned_playername"), res.getString("banned_uuid"), res.getString("banned_ip"), res.getString("banned_by"), res.getString("reason"), res.getString("type"), res.getTimestamp("banned_on"), res.getTimestamp("banned_until")));
+            }
+
+            res.close();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        finally {
+            connectionHandler.release();
+        }
+        return bans;
+    }
+
+    public Ban getBanInfo(String player)
+    {
+        return getBanInfo(player, player, player);
+    }
+
+    public Ban getBanInfo(String player, String uuid, String ip)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
 
         Ban b = null;
@@ -83,84 +149,109 @@ public class Bans implements IRepository {
         try {
             PreparedStatement banInfo = connectionHandler.getPreparedStatement("banInfo");
             banInfo.setString(1, player);
+            banInfo.setString(2, uuid);
+            banInfo.setString(3, ip);
 
             ResultSet res = banInfo.executeQuery();
             while (res.next()) {
-                b = new Ban(res.getInt("id"), res.getString("display"), res.getString("banned_by"), res.getString("reason"), res.getString("type"), res.getTimestamp("banned_on"), res.getTimestamp("banned_until"));
+                b = new Ban(res.getInt("id"), res.getString("banned_playername"), res.getString("banned_uuid"), res.getString("banned_ip"), res.getString("banned_by"), res.getString("reason"), res.getString("type"), res.getTimestamp("banned_on"), res.getTimestamp("banned_until"));
             }
 
             res.close();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
 
         return b;
     }
 
-    public void unbanPlayer(int id) {
+    public void unbanPlayer(int id)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
 
         try {
             PreparedStatement unbanPlayer = connectionHandler.getPreparedStatement("unbanPlayer");
             unbanPlayer.setInt(1, id);
             unbanPlayer.executeUpdate();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
     }
 
-    public void insertBanConvert(String bannedBy, String player, String reason, String type, Date bannedOn, Date bannedUntil) {
+    public void insertBanConvert(String bannedBy, String player, String reason, String type, Date bannedOn, Date bannedUntil)
+    {
+        insertBanConvert(bannedBy, player, null, null, reason, type, bannedOn, bannedUntil);
+    }
+
+    public void insertBanConvert(String bannedBy, String player, String uuid, String ip, String reason, String type, Date bannedOn, Date bannedUntil)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
 
         try {
             PreparedStatement insertBanConvert = connectionHandler.getPreparedStatement("insertBanConvert");
-            insertBanConvert.setString(1, player);
-            insertBanConvert.setString(2, player);
-            insertBanConvert.setString(3, bannedBy);
-            insertBanConvert.setString(4, reason);
-            insertBanConvert.setString(5, type);
-            insertBanConvert.setDate(6, bannedOn);
-            insertBanConvert.setDate(7, bannedUntil);
+            insertBanConvert.setString(1, player); //playerName
+            insertBanConvert.setString(2, uuid); //UUID
+            insertBanConvert.setString(3, ip); //IP
+            insertBanConvert.setString(4, bannedBy);
+            insertBanConvert.setString(5, reason);
+            insertBanConvert.setString(6, type);
+            insertBanConvert.setDate(7, bannedOn);
+            insertBanConvert.setDate(8, bannedUntil);
 
             insertBanConvert.executeUpdate();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
     }
 
     @Override
-    public String[] getTable() {
-        return new String[]{"bans", "id INT(11) NOT NULL AUTO_INCREMENT," +
-                "display VARCHAR(100), " +
-                "banned_entity VARCHAR(100), " +
-                "banned_by VARCHAR(100), " +
-                "reason VARCHAR(255), " +
-                "type VARCHAR(100), " +
-                "banned_on DATETIME NOT NULL," +
-                "banned_until DATETIME, " +
-                "CONSTRAINT pk_banid PRIMARY KEY (id)"};
+    public String[] getTable()
+    {
+        return new String[]{"bans", "id INT(11) NOT NULL AUTO_INCREMENT,"
+            + "banned_playername VARCHAR(100), "
+            + "banned_uuid VARCHAR(100), "
+            + "banned_ip VARCHAR(15), "
+            + "banned_by VARCHAR(100), "
+            + "reason VARCHAR(255), "
+            + "type VARCHAR(100), "
+            + "banned_on DATETIME NOT NULL,"
+            + "banned_until DATETIME, "
+            + "CONSTRAINT pk_banid PRIMARY KEY (id)"};
     }
 
     @Override
-    public void registerPreparedStatements(ConnectionHandler connection) {
-        connection.addPreparedStatement("isPlayerBanned", "SELECT id FROM bans WHERE banned_entity = ? AND type <> 'unban'");
-        connection.addPreparedStatement("banPlayer", "INSERT INTO bans (display,banned_entity,banned_by,reason,type,banned_on) VALUES (?,?,?,?,?,NOW());");
+    public void registerPreparedStatements(ConnectionHandler connection)
+    {
+        connection.addPreparedStatement("isPlayerBanned", "SELECT id FROM bans WHERE (banned_playername = ? OR banned_uuid = ? OR banned_ip = ?) AND type <> 'unban'");
+        connection.addPreparedStatement("banPlayer", "INSERT INTO bans (banned_playername,banned_uuid,banned_ip,banned_by,reason,type,banned_on) VALUES (?,?,?,?,?,?,NOW());");
         connection.addPreparedStatement("unbanPlayer", "UPDATE bans SET type = 'unban' WHERE id = ?");
-        connection.addPreparedStatement("banInfo", "SELECT * FROM bans WHERE banned_entity = ? AND type <> 'unban'");
-        connection.addPreparedStatement("tempBanPlayer", "INSERT INTO bans (display,banned_entity,banned_by,reason,type,banned_on,banned_until) VALUES(?,?,?,?,'tempban',NOW(),?)");
-        connection.addPreparedStatement("insertBanConvert", "INSERT INTO bans (display,banned_entity,banned_by,reason,type,banned_on,banned_until) VALUES(?,?,?,?,?,?,?)");
+        connection.addPreparedStatement("banInfo", "SELECT * FROM bans WHERE (banned_playername = ? OR banned_uuid = ? OR banned_ip = ?) AND type <> 'unban'");
+        connection.addPreparedStatement("banHistory", "SELECT * FROM bans WHERE (banned_playername = ? OR banned_uuid = ? OR banned_ip = ?) ORDER BY id ASC");
+        connection.addPreparedStatement("tempBanPlayer", "INSERT INTO bans (banned_playername,banned_uuid,banned_by,reason,type,banned_on,banned_until) VALUES(?,?,?,?,'tempban',NOW(),?)");
+        connection.addPreparedStatement("insertBanConvert", "INSERT INTO bans (banned_playername,banned_uuid,banned_by,reason,type,banned_on,banned_until) VALUES(?,?,?,?,?,?,?)");
         connection.addPreparedStatement("getBans", "SELECT * FROM bans");
-        connection.addPreparedStatement("updateToUUID", "UPDATE bans SET banned_entity = ? WHERE id = ?");
+        connection.addPreparedStatement("updateRowUUID", "UPDATE bans SET banned_uuid = ? WHERE id = ?");
+        connection.addPreparedStatement("updateToUUID", "UPDATE bans SET banned_uuid = ? WHERE id = ?");
+        connection.addPreparedStatement("updateToVersion3-part1", "ALTER TABLE `bans` CHANGE `display` `banned_playername` VARCHAR( 100 );  ");
+        connection.addPreparedStatement("updateToVersion3-part2", "ALTER TABLE `bans` CHANGE `banned_entity` `banned_uuid` VARCHAR( 100 );  ");
+        connection.addPreparedStatement("updateToVersion3-part3", "ALTER TABLE `bans` ADD `banned_ip` VARCHAR( 15 ) NULL AFTER `banned_uuid`  ");
     }
 
     @Override
-    public void checkUpdate() {
+    public void checkUpdate()
+    {
         //What current Version of the Database is this ?
         int installedVersion = ConfigManager.main.Version_Database_Ban;
 
@@ -175,8 +266,8 @@ public class Bans implements IRepository {
                 PreparedStatement getBans = connectionHandler.getPreparedStatement("getBans");
                 try {
                     ResultSet res = getBans.executeQuery();
-                    while(res.next()) {
-                        String bannedEntity = res.getString("banned_entity");
+                    while (res.next()) {
+                        String bannedEntity = res.getString("banned_uuid");
 
                         if (!Utilities.isIPAddress(bannedEntity)) {
                             String uuid = Utilities.getUUID(bannedEntity);
@@ -189,30 +280,63 @@ public class Bans implements IRepository {
                                     updateToUUID.setString(1, uuid);
                                     updateToUUID.setInt(2, res.getInt("id"));
                                     updateToUUID.executeUpdate();
-                                } catch (SQLException e) {
+                                }
+                                catch (SQLException e) {
                                     System.out.println("Could not update Ban for update to version 2");
                                     e.printStackTrace();
-                                } finally {
+                                }
+                                finally {
                                     connectionHandler1.release();
                                 }
                             }
                         }
                     }
-                } catch (SQLException e) {
+                }
+                catch (SQLException e) {
                     System.out.println("Could not get Bans for update to version 2");
                     e.printStackTrace();
                     return;
-                } finally {
+                }
+                finally {
                     connectionHandler.release();
                 }
             }
         }
 
-        ConfigManager.main.Version_Database_Ban = 2;
-        try {
-            ConfigManager.main.save();
-        } catch (InvalidConfigurationException e) {
-            e.printStackTrace();
+        if (installedVersion < 3) { //dimensionZ aggressive+freedom-of-ban update
+            ConnectionHandler connectionHandler = null;
+            boolean updateCompleted = false;
+            try {
+                connectionHandler = DatabaseManager.connectionPool.getConnection();
+                PreparedStatement updateToVersion3 = connectionHandler.getPreparedStatement("updateToVersion3-part1");
+                updateToVersion3.executeUpdate();
+                updateToVersion3 = connectionHandler.getPreparedStatement("updateToVersion3-part2");
+                updateToVersion3.executeUpdate();
+                updateToVersion3 = connectionHandler.getPreparedStatement("updateToVersion3-part3");
+                updateToVersion3.executeUpdate();
+                System.out.println("Updated Bans to version 3!");
+                updateCompleted = true;
+            }
+            catch (SQLException ex) {
+                System.out.println("Could not get Bans for update to version 3");
+                Logger.getLogger(Bans.class.getName()).log(Level.SEVERE, null, ex);
+            }
+            finally {
+                if (connectionHandler != null) {
+                    connectionHandler.release();
+                }
+            }
+            if (!updateCompleted) {
+                return;
+            }
+            ConfigManager.main.Version_Database_Ban = 3;
+            try {
+                ConfigManager.main.save();
+            }
+            catch (InvalidConfigurationException e) {
+                e.printStackTrace();
+            }
         }
+
     }
 }

--- a/src/main/java/net/cubespace/geSuit/database/Players.java
+++ b/src/main/java/net/cubespace/geSuit/database/Players.java
@@ -1,5 +1,9 @@
 package net.cubespace.geSuit.database;
 
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import net.cubespace.Yamler.Config.InvalidConfigurationException;
 import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.Utilities;
@@ -7,107 +11,117 @@ import net.cubespace.geSuit.managers.ConfigManager;
 import net.cubespace.geSuit.managers.DatabaseManager;
 import net.cubespace.geSuit.objects.GSPlayer;
 
-import java.sql.Date;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 /**
  * @author geNAZt (fabian.fassbender42@googlemail.com)
  */
-public class Players implements IRepository {
-    public boolean playerExists(String player) {
-        ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
+public class Players implements IRepository
+{
 
+    public boolean playerExists(String player)
+    {
+        ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
+        
         try {
             PreparedStatement playerExists = connectionHandler.getPreparedStatement("playerExists");
             playerExists.setString(1, player);
             playerExists.setString(2, player);
-
+            
             return playerExists.executeQuery().next();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
-
+        
         return true;
     }
-
-    public String getPlayerIP(String player) {
+    
+    public String getPlayerIP(String player)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
-
+        
         try {
             PreparedStatement getPlayerIP = connectionHandler.getPreparedStatement("getPlayerIP");
             getPlayerIP.setString(1, player);
             getPlayerIP.setString(2, player);
-
+            
             String ip = null;
             ResultSet res = getPlayerIP.executeQuery();
             while (res.next()) {
                 ip = res.getString("ipaddress");
             }
             res.close();
-
+            
             return ip;
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
-
+        
         return null;
     }
-
-    public boolean getPlayerTPS(String player) {
+    
+    public boolean getPlayerTPS(String player)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
-
+        
         try {
             PreparedStatement getPlayerTPS = connectionHandler.getPreparedStatement("getPlayerTPS");
             getPlayerTPS.setString(1, player);
             getPlayerTPS.setString(2, player);
-
+            
             boolean tps = true;
             ResultSet res = getPlayerTPS.executeQuery();
             while (res.next()) {
                 tps = res.getBoolean("tps");
             }
             res.close();
-
+            
             return tps;
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
-
+        
         return true;
     }
-
-    public void insertPlayer(GSPlayer player, String ip) {
+    
+    public void insertPlayer(GSPlayer player, String ip)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
-
+        
         try {
             PreparedStatement insertPlayer = connectionHandler.getPreparedStatement("insertPlayer");
             insertPlayer.setString(1, player.getName());
             insertPlayer.setString(2, player.getUuid());
             insertPlayer.setString(3, ip);
-
+            
             insertPlayer.executeUpdate();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
     }
-
-    public void insertPlayerConvert(String player, Date lastonline, String ip, boolean tps) {
+    
+    public void insertPlayerConvert(String player, Date lastonline, String ip, boolean tps)
+    {
         String uuid = (FeatureDetector.canUseUUID()) ? Utilities.getUUID(player) : null;
-
+        
         if (FeatureDetector.canUseUUID() && uuid == null) {
             return;
         }
-
+        
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
         try {
             PreparedStatement insertPlayerConvert = connectionHandler.getPreparedStatement("insertPlayerConvert");
@@ -116,102 +130,115 @@ public class Players implements IRepository {
             insertPlayerConvert.setDate(3, lastonline);
             insertPlayerConvert.setString(4, ip);
             insertPlayerConvert.setBoolean(5, tps);
-
+            
             insertPlayerConvert.executeUpdate();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
     }
-
-    public void updatePlayer(GSPlayer gsPlayer) {
+    
+    public void updatePlayer(GSPlayer gsPlayer)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
-
+        
         try {
             PreparedStatement updatePlayer = connectionHandler.getPreparedStatement("updatePlayer");
             updatePlayer.setString(1, gsPlayer.getUuid());
             updatePlayer.setString(2, gsPlayer.getName());
             updatePlayer.setString(3, gsPlayer.getName());
             updatePlayer.setString(4, gsPlayer.getUuid());
-
+            
             updatePlayer.executeUpdate();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
     }
-
-    public GSPlayer loadPlayer(String player) {
+    
+    public GSPlayer loadPlayer(String player)
+    {
         ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
-
+        
         GSPlayer player1 = null;
         try {
             PreparedStatement getPlayer = connectionHandler.getPreparedStatement("getPlayer");
             getPlayer.setString(1, player);
             getPlayer.setString(2, player);
-
+            
             ResultSet res = getPlayer.executeQuery();
             while (res.next()) {
-                player1 = new GSPlayer(res.getString("playername"), res.getString("uuid"), res.getBoolean("tps"));
+                player1 = new GSPlayer(res.getString("playername"), res.getString("uuid"), res.getBoolean("tps"), res.getString("ipaddress"), res.getTimestamp("lastonline"));
             }
-
+            
             res.close();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
-        } finally {
+        }
+        finally {
             connectionHandler.release();
         }
-
+        
         return player1;
     }
-
+    
     @Override
-    public String[] getTable() {
-        return new String[]{"players", "playername VARCHAR(100), " +
-                "`uuid` VARCHAR(100) NULL UNIQUE," +
-                "lastonline DATETIME NOT NULL, " +
-                "ipaddress VARCHAR(100), " +
-                "tps TINYINT(1) DEFAULT 1," +
-                ((FeatureDetector.canUseUUID()) ?
-                        "CONSTRAINT pk_uuid PRIMARY KEY (uuid)" :
-                        "CONSTRAINT pk_playername PRIMARY KEY (playername)")};
+    public String[] getTable()
+    {
+        return new String[]{"players", "playername VARCHAR(100), "
+            + "`uuid` VARCHAR(100) NULL UNIQUE,"
+            + "lastonline DATETIME NOT NULL, "
+            + "ipaddress VARCHAR(100), "
+            + "tps TINYINT(1) DEFAULT 1,"
+            + ((FeatureDetector.canUseUUID())
+            ? "CONSTRAINT pk_uuid PRIMARY KEY (uuid)"
+            : "CONSTRAINT pk_playername PRIMARY KEY (playername)")};
     }
-
+    
     @Override
-    public void registerPreparedStatements(ConnectionHandler connection) {
+    public void registerPreparedStatements(ConnectionHandler connection)
+    {
         connection.addPreparedStatement("getPlayerIP", "SELECT ipaddress FROM players WHERE playername = ? OR uuid = ?");
         connection.addPreparedStatement("playerExists", "SELECT playername FROM players WHERE playername = ? OR uuid = ?");
-        connection.addPreparedStatement("getPlayer", "SELECT playername,uuid,tps FROM players WHERE playername = ? OR uuid = ?");
         connection.addPreparedStatement("getPlayerTPS", "SELECT tps FROM players WHERE playername = ? OR uuid = ?");
+        connection.addPreparedStatement("getPlayer", "SELECT * FROM players WHERE playername = ? OR uuid = ?");
         connection.addPreparedStatement("insertPlayer", "INSERT INTO players (playername,uuid,lastonline,ipaddress) VALUES (?, ?, NOW(), ?)");
         connection.addPreparedStatement("insertPlayerConvert", "INSERT INTO players (playername,uuid,lastonline,ipaddress,tps) VALUES (?, ?, ?, ?, ?)");
         connection.addPreparedStatement("getPlayers", "SELECT * FROM players");
         connection.addPreparedStatement("setUUID", "UPDATE players SET uuid = ? WHERE playername = ?");
         connection.addPreparedStatement("updatePlayer", "UPDATE players SET uuid = ?, playername = ?, lastonline = NOW() WHERE playername = ? OR uuid = ?");
     }
-
+    
     @Override
-    public void checkUpdate() {
+    public void checkUpdate()
+    {
         int installedVersion = ConfigManager.main.Version_Database_Players;
-
+        
         System.out.println("Current Version of the Players Database: " + installedVersion);
-
+        
         if (installedVersion < 2) {
             // Version 2 adds UUIDs as Field
             ConnectionHandler connectionHandler = DatabaseManager.connectionPool.getConnection();
-
+            
             try {
                 connectionHandler.getConnection().createStatement().execute("ALTER TABLE `players` ADD `uuid` VARCHAR(100) NULL AFTER `playername`, ADD UNIQUE (`uuid`) ;");
-            } catch (SQLException e) {
+            }
+            catch (SQLException e) {
                 System.out.println("Could not update the Player Database to version 2");
                 e.printStackTrace();
                 return;
-            } finally {
+            }
+            finally {
                 connectionHandler.release();
             }
-
+            
             if (FeatureDetector.canUseUUID()) {
                 connectionHandler = DatabaseManager.connectionPool.getConnection();
 
@@ -219,41 +246,47 @@ public class Players implements IRepository {
                 PreparedStatement getPlayers = connectionHandler.getPreparedStatement("getPlayers");
                 try {
                     ResultSet res = getPlayers.executeQuery();
-                    while(res.next()) {
+                    while (res.next()) {
                         String playername = res.getString("playername");
                         String uuid = Utilities.getUUID(playername);
-
+                        
                         if (uuid != null) {
                             ConnectionHandler connectionHandler1 = DatabaseManager.connectionPool.getConnection();
-
+                            
                             try {
                                 PreparedStatement preparedStatement = connectionHandler1.getPreparedStatement("setUUID");
                                 preparedStatement.setString(1, uuid);
                                 preparedStatement.setString(2, playername);
                                 preparedStatement.executeUpdate();
-                            } catch (SQLException e) {
+                            }
+                            catch (SQLException e) {
                                 System.out.println("Could not update Player for update to version 2");
                                 e.printStackTrace();
-                            } finally {
+                            }
+                            finally {
                                 connectionHandler1.release();
                             }
                         }
                     }
-                } catch (SQLException e) {
+                }
+                catch (SQLException e) {
                     System.out.println("Could not get Players for update to version 2");
                     e.printStackTrace();
                     return;
-                } finally {
+                }
+                finally {
                     connectionHandler.release();
                 }
             }
         }
-
+        
         ConfigManager.main.Version_Database_Players = 2;
         try {
             ConfigManager.main.save();
-        } catch (InvalidConfigurationException e) {
+        }
+        catch (InvalidConfigurationException e) {
             e.printStackTrace();
         }
     }
+    
 }

--- a/src/main/java/net/cubespace/geSuit/events/NewPlayerJoinEvent.java
+++ b/src/main/java/net/cubespace/geSuit/events/NewPlayerJoinEvent.java
@@ -1,0 +1,35 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.cubespace.geSuit.events;
+
+import net.md_5.bungee.api.plugin.Event;
+
+/**
+ *
+ * @author JR
+ */
+public class NewPlayerJoinEvent extends Event
+{
+
+    private String message;
+    private String player;
+
+    public NewPlayerJoinEvent(String playerName, String message)
+    {
+        this.player = playerName;
+        this.message = message;
+    }
+
+    public String getMessage()
+    {
+        return message;
+    }
+
+    public String getPlayer()
+    {
+        return player;
+    }
+}

--- a/src/main/java/net/cubespace/geSuit/geSuit.java
+++ b/src/main/java/net/cubespace/geSuit/geSuit.java
@@ -3,6 +3,7 @@ package net.cubespace.geSuit;
 import net.cubespace.geSuit.commands.BanCommand;
 import net.cubespace.geSuit.commands.MOTDCommand;
 import net.cubespace.geSuit.commands.ReloadCommand;
+import net.cubespace.geSuit.commands.SeenCommand;
 import net.cubespace.geSuit.commands.UnbanCommand;
 import net.cubespace.geSuit.database.ConnectionHandler;
 import net.cubespace.geSuit.database.convert.Converter;
@@ -52,6 +53,9 @@ public class geSuit extends Plugin
         // A little hardcore. Prevent updating without a restart. But command squatting = bad!
         if (ConfigManager.main.MOTD_Enabled) {
             proxy.getPluginManager().registerCommand(this, new MOTDCommand());
+        }
+        if (ConfigManager.main.Seen_Enabled) {
+            proxy.getPluginManager().registerCommand(this, new SeenCommand());
         }
         proxy.getPluginManager().registerCommand(this, new UnbanCommand());
         proxy.getPluginManager().registerCommand(this, new BanCommand());

--- a/src/main/java/net/cubespace/geSuit/geSuit.java
+++ b/src/main/java/net/cubespace/geSuit/geSuit.java
@@ -1,7 +1,9 @@
 package net.cubespace.geSuit;
 
+import net.cubespace.geSuit.commands.BanCommand;
 import net.cubespace.geSuit.commands.MOTDCommand;
 import net.cubespace.geSuit.commands.ReloadCommand;
+import net.cubespace.geSuit.commands.UnbanCommand;
 import net.cubespace.geSuit.database.ConnectionHandler;
 import net.cubespace.geSuit.database.convert.Converter;
 import net.cubespace.geSuit.listeners.BansListener;
@@ -51,6 +53,8 @@ public class geSuit extends Plugin
         if (ConfigManager.main.MOTD_Enabled) {
             proxy.getPluginManager().registerCommand(this, new MOTDCommand());
         }
+        proxy.getPluginManager().registerCommand(this, new UnbanCommand());
+        proxy.getPluginManager().registerCommand(this, new BanCommand());
         proxy.getPluginManager().registerCommand(this, new ReloadCommand());
     }
 

--- a/src/main/java/net/cubespace/geSuit/listeners/BansListener.java
+++ b/src/main/java/net/cubespace/geSuit/listeners/BansListener.java
@@ -1,5 +1,8 @@
 package net.cubespace.geSuit.listeners;
 
+import java.sql.SQLException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.managers.BansManager;
@@ -12,20 +15,16 @@ import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 
-import java.sql.SQLException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 public class BansListener implements Listener {
     private static SimpleDateFormat sdf = new SimpleDateFormat("dd MMM yyyy HH:mm:ss z");
 
     @EventHandler
     public void banCheck(LoginEvent e) throws SQLException {
-        if (DatabaseManager.bans.isPlayerBanned((FeatureDetector.canUseUUID()) ? e.getConnection().getUUID() : e.getConnection().getName()) || DatabaseManager.bans.isPlayerBanned(e.getConnection().getAddress().getHostString())) {
-            Ban b = DatabaseManager.bans.getBanInfo((FeatureDetector.canUseUUID()) ? e.getConnection().getUUID() : e.getConnection().getName());
+        if (DatabaseManager.bans.isPlayerBanned(e.getConnection().getName(), ((FeatureDetector.canUseUUID()) ? e.getConnection().getUUID() : null), e.getConnection().getAddress().getHostString())) {
+            Ban b = DatabaseManager.bans.getBanInfo(e.getConnection().getName(), ((FeatureDetector.canUseUUID()) ? e.getConnection().getUUID() : null), e.getConnection().getAddress().getHostString());
 
             if (b == null) {
-                b = DatabaseManager.bans.getBanInfo(e.getConnection().getAddress().getHostString());
+                return;
             }
 
             if (b.getType().equals("tempban")) {

--- a/src/main/java/net/cubespace/geSuit/listeners/BansMessageListener.java
+++ b/src/main/java/net/cubespace/geSuit/listeners/BansMessageListener.java
@@ -1,16 +1,15 @@
 package net.cubespace.geSuit.listeners;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.sql.SQLException;
 import net.cubespace.geSuit.managers.BansManager;
 import net.cubespace.geSuit.managers.LoggingManager;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
-
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.sql.SQLException;
 
 public class BansMessageListener implements Listener {
 
@@ -58,6 +57,10 @@ public class BansMessageListener implements Listener {
         }
         if (task.equals("CheckPlayerBans")) {
             BansManager.checkPlayersBan(in.readUTF(), in.readUTF());
+            return;
+        }
+        if (task.equals("DisplayPlayerBanHistory")) {
+            BansManager.displayPlayerBanHistory(in.readUTF(), in.readUTF());
             return;
         }
         if (task.equals("ReloadBans")) {

--- a/src/main/java/net/cubespace/geSuit/listeners/PlayerListener.java
+++ b/src/main/java/net/cubespace/geSuit/listeners/PlayerListener.java
@@ -33,7 +33,7 @@ public class PlayerListener implements Listener {
             }
 
             if (ConfigManager.main.MOTD_Enabled) {
-                PlayerManager.sendMessageToPlayer(e.getPlayer().getName(), ConfigManager.messages.MOTD.replace("{player}", p.getName()));
+                PlayerManager.sendMessageToTarget(e.getPlayer().getName(), ConfigManager.messages.MOTD.replace("{player}", p.getName()));
             }
 
             p.connected();

--- a/src/main/java/net/cubespace/geSuit/listeners/PortalsMessageListener.java
+++ b/src/main/java/net/cubespace/geSuit/listeners/PortalsMessageListener.java
@@ -1,5 +1,9 @@
 package net.cubespace.geSuit.listeners;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.sql.SQLException;
 import net.cubespace.geSuit.managers.ConfigManager;
 import net.cubespace.geSuit.managers.LoggingManager;
 import net.cubespace.geSuit.managers.PlayerManager;
@@ -10,11 +14,6 @@ import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
-
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.IOException;
-import java.sql.SQLException;
 
 public class PortalsMessageListener implements Listener {
 
@@ -44,7 +43,7 @@ public class PortalsMessageListener implements Listener {
             GSPlayer sender = PlayerManager.getPlayer(in.readUTF());
             boolean selection = in.readBoolean();
             if (!selection) {
-                sender.sendMessage(ConfigManager.messages.NO_SELECTION_MADE);
+                PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.NO_SELECTION_MADE);
             } else {
                 PortalManager.setPortal(sender, in.readUTF(), in.readUTF(), in.readUTF(), in.readUTF(), new Location(s.getInfo(), in.readUTF(), in.readDouble(), in.readDouble(), in.readDouble()), new Location(s.getInfo(), in.readUTF(), in.readDouble(), in.readDouble(), in.readDouble()));
             }

--- a/src/main/java/net/cubespace/geSuit/managers/BansManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/BansManager.java
@@ -1,7 +1,10 @@
 package net.cubespace.geSuit.managers;
 
+import java.sql.Date;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.List;
 import net.cubespace.Yamler.Config.InvalidConfigurationException;
-import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.objects.Ban;
 import net.cubespace.geSuit.objects.GSPlayer;
@@ -9,101 +12,123 @@ import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-import java.sql.Date;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
+public class BansManager
+{
 
-public class BansManager {
-    public static void banPlayer(String bannedBy, String player, String reason) {
+    public static void banPlayer(String bannedBy, String player, String reason)
+    {
         GSPlayer p = PlayerManager.getPlayer(bannedBy);
         GSPlayer t = PlayerManager.getSimilarPlayer(player);
 
+        if (DatabaseManager.bans.isPlayerBanned(player)) {
+            if (p == null) {
+                ProxyServer.getInstance().getConsole().sendMessage(Utilities.colorize(ConfigManager.messages.PLAYER_ALREADY_BANNED));
+            }
+            else {
+                p.sendMessage(ConfigManager.messages.PLAYER_ALREADY_BANNED);
+            }
+            return;
+        }
+
         if (t == null) {
-            p.sendMessage(ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
-            return;
+            if (p == null) {
+                ProxyServer.getInstance().getConsole().sendMessage(Utilities.colorize(ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING));
+            }
+            else {
+                p.sendMessage(ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING);
+            }
         }
 
-        if (DatabaseManager.bans.isPlayerBanned(t.getName()) || DatabaseManager.bans.isPlayerBanned(DatabaseManager.players.getPlayerIP(t.getName()))) {
-            p.sendMessage(ConfigManager.messages.PLAYER_ALREADY_BANNED);
-            return;
+        if (reason == null || reason.equals("")) {
+            //Even there we colorize. After all it's colored on the ban screen
+            reason = Utilities.colorize(ConfigManager.messages.DEFAULT_BAN_REASON);
         }
 
-        if (reason.equals("")) {
-            reason = ConfigManager.messages.DEFAULT_BAN_REASON;
-        }
+        int id = DatabaseManager.bans.banPlayer(player, (t != null && t.getUuid() != null) ? t.getUuid() : null, null, bannedBy, reason, "ban");
 
-        DatabaseManager.bans.banPlayer(player, bannedBy, (t.getUuid() != null) ? t.getUuid() : t.getName(), reason, "ban");
+        Utilities.databaseUpdateRowUUID(id, player);
 
-        if (t.getProxiedPlayer() != null) {
-            disconnectPlayer(t.getProxiedPlayer(), ConfigManager.messages.BAN_PLAYER_MESSAGE.replace("{message}", reason).replace("{sender}", bannedBy));
+        if (t != null && t.getProxiedPlayer() != null) {
+            disconnectPlayer(t.getProxiedPlayer(), Utilities.colorize(ConfigManager.messages.BAN_PLAYER_MESSAGE.replace("{message}", reason).replace("{sender}", bannedBy)));
         }
 
         if (ConfigManager.bans.BroadcastBans) {
-            PlayerManager.sendBroadcast(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
-        } else {
-            p.sendMessage(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
+            PlayerManager.sendBroadcast(Utilities.colorize(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy)));
         }
+        else {
+            if (p == null) {
+                ProxyServer.getInstance().getConsole().sendMessage(Utilities.colorize(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy)));
+            }
+            else {
+                p.sendMessage(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
+            }
+        }
+
     }
 
-    public static void unbanPlayer(String sender, String player) {
-        if (!Utilities.isIPAddress(player) && !DatabaseManager.players.playerExists(player)) {
-            PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
-            return;
-        }
+    public static void unbanPlayer(String sender, String player)
+    {
+//        if (!Utilities.isIPAddress(player) && !DatabaseManager.players.playerExists(player)) {
+//            PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
+//            return;
+//        }
 
-        if (!DatabaseManager.bans.isPlayerBanned(player) && !DatabaseManager.bans.isPlayerBanned(DatabaseManager.players.getPlayerIP(player))) {
+        if (!DatabaseManager.bans.isPlayerBanned(player, player, player)) {
             PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_NOT_BANNED);
             return;
         }
 
-        GSPlayer p = DatabaseManager.players.loadPlayer(player);
-        Ban b = DatabaseManager.bans.getBanInfo((FeatureDetector.canUseUUID()) ? p.getUuid() : p.getName());
-
-        if (b == null) {
-            b = DatabaseManager.bans.getBanInfo(DatabaseManager.players.getPlayerIP(player));
-        }
+        Ban b = DatabaseManager.bans.getBanInfo(player);
 
         DatabaseManager.bans.unbanPlayer(b.getId());
 
         if (ConfigManager.bans.BroadcastBans) {
-            PlayerManager.sendBroadcast(ConfigManager.messages.PLAYER_UNBANNED.replace("{player}", player).replace("{sender}", sender));
-        } else {
-            PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_UNBANNED.replace("{player}", player).replace("{sender}", sender));
+            PlayerManager.sendBroadcast(ConfigManager.messages.PLAYER_UNBANNED.replace("{player}", b.getPlayer()).replace("{sender}", sender));
+        }
+        else {
+            PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_UNBANNED.replace("{player}", b.getPlayer()).replace("{sender}", sender));
         }
     }
 
-    public static void banIP(String bannedBy, String player, String reason) {
+    public static void banIP(String bannedBy, String player, String reason)
+    {
         if (reason.equals("")) {
-            reason = ConfigManager.messages.DEFAULT_BAN_REASON;
+            reason = Utilities.colorize(ConfigManager.messages.DEFAULT_BAN_REASON);
         }
 
         String ip;
         if (Utilities.isIPAddress(player)) {
             ip = player;
-        } else {
-            GSPlayer t = PlayerManager.getSimilarPlayer(player);
-            ip = DatabaseManager.players.getPlayerIP(t.getName());
+        }
+        else {
+            ip = DatabaseManager.players.getPlayerIP(player);
+        }
+
+        if (ip == null) {
+            PlayerManager.sendMessageToPlayer(bannedBy, ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
+            return;
         }
 
         if (!DatabaseManager.bans.isPlayerBanned(ip)) {
-            DatabaseManager.bans.banPlayer(player, bannedBy, ip, reason, "ipban");
+            DatabaseManager.bans.banPlayer(player, null, ip, bannedBy, reason, "ipban");
         }
 
-        if (!Utilities.isIPAddress(player)) {
-            GSPlayer t = PlayerManager.getSimilarPlayer(player);
-            if (t.getProxiedPlayer() != null) {
-                disconnectPlayer(ProxyServer.getInstance().getPlayer(player), ConfigManager.messages.IPBAN_PLAYER.replace("{message}", reason).replace("{sender}", bannedBy));
+        for (GSPlayer p : PlayerManager.getPlayersByIP(ip)) {
+            if (p.getProxiedPlayer() != null) {
+                disconnectPlayer(p.getProxiedPlayer(), ConfigManager.messages.IPBAN_PLAYER.replace("{message}", reason).replace("{sender}", bannedBy));
             }
         }
 
         if (ConfigManager.bans.BroadcastBans) {
             PlayerManager.sendBroadcast(ConfigManager.messages.IPBAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
-        } else {
+        }
+        else {
             PlayerManager.sendMessageToPlayer(bannedBy, ConfigManager.messages.IPBAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
         }
     }
 
-    public static void kickAll(String sender, String message) {
+    public static void kickAll(String sender, String message)
+    {
         if (message.equals("")) {
             message = ConfigManager.messages.DEFAULT_KICK_MESSAGE;
         }
@@ -115,17 +140,22 @@ public class BansManager {
         }
     }
 
-    public static void checkPlayersBan(String sender, String player) {
+    public static void checkPlayersBan(String sender, String player)
+    {
         GSPlayer p = PlayerManager.getPlayer(sender);
         Ban b = DatabaseManager.bans.getBanInfo(player);
 
         if (b == null) {
             p.sendMessage(ConfigManager.messages.PLAYER_NOT_BANNED);
-        } else {
+        }
+        else {
             SimpleDateFormat sdf = new SimpleDateFormat();
             sdf.applyPattern("dd MMM yyyy HH:mm:ss z");
             p.sendMessage(ChatColor.DARK_AQUA + "--------" + ChatColor.DARK_RED + "Ban Info" + ChatColor.DARK_AQUA + "--------");
             p.sendMessage(ChatColor.RED + "Player: " + ChatColor.AQUA + b.getPlayer());
+            if (b.getUuid() != null) {
+                p.sendMessage(ChatColor.RED + "UUID: " + ChatColor.AQUA + b.getUuid());
+            }
             p.sendMessage(ChatColor.RED + "Ban type: " + ChatColor.AQUA + b.getType());
             p.sendMessage(ChatColor.RED + "Banned by: " + ChatColor.AQUA + b.getBannedBy());
             p.sendMessage(ChatColor.RED + "Ban reason: " + ChatColor.AQUA + b.getReason());
@@ -133,13 +163,40 @@ public class BansManager {
 
             if (b.getBannedUntil() == null) {
                 p.sendMessage(ChatColor.RED + "Bannned until: " + ChatColor.AQUA + "-Forever-");
-            } else {
+            }
+            else {
                 p.sendMessage(ChatColor.RED + "Bannned until: " + ChatColor.AQUA + sdf.format(b.getBannedUntil()));
             }
         }
     }
 
-    public static void kickPlayer(String sender, String player, String reason) {
+    public static void displayPlayerBanHistory(String sender, String player)
+    {
+        GSPlayer p = PlayerManager.getPlayer(sender);
+        List<Ban> bans = DatabaseManager.bans.getBanHistory(player);
+
+        if (bans == null || bans.isEmpty()) {
+            p.sendMessage(Utilities.colorize(ConfigManager.messages.PLAYER_NEVER_BANNED.replace("{player}", player)));
+            return;
+        }
+        p.sendMessage(ChatColor.DARK_AQUA + "--------" + ChatColor.DARK_RED + player + "'s Ban History" + ChatColor.DARK_AQUA + "--------");
+        boolean first = true;
+        for (Ban b : bans) {
+            if (first) {
+                first = false;
+            }
+            else {
+                p.sendMessage("");
+            }
+            SimpleDateFormat sdf = new SimpleDateFormat();
+            sdf.applyPattern("dd MMM yyyy HH:mm");
+            p.sendMessage((b.getBannedUntil() != null ? ChatColor.GOLD + "| " : ChatColor.RED + "| ") + "Date: " + ChatColor.AQUA + sdf.format(b.getBannedOn()) + ChatColor.RED + (b.getBannedUntil() != null ? ChatColor.DARK_AQUA + " > " + sdf.format(b.getBannedUntil()) : ChatColor.DARK_AQUA + " > forever"));
+            p.sendMessage((b.getBannedUntil() != null ? ChatColor.GOLD + "| " : ChatColor.RED + "| ") + "Banned by " + ChatColor.AQUA + b.getBannedBy() + ChatColor.DARK_AQUA + " (" + ChatColor.GRAY + b.getReason() + ChatColor.DARK_AQUA + ")");
+        }
+    }
+
+    public static void kickPlayer(String sender, String player, String reason)
+    {
         if (reason.equals("")) {
             reason = ConfigManager.messages.DEFAULT_KICK_MESSAGE;
         }
@@ -157,31 +214,38 @@ public class BansManager {
         }
     }
 
-    public static void disconnectPlayer(ProxiedPlayer player, String message) {
+    public static void disconnectPlayer(ProxiedPlayer player, String message)
+    {
         PlayerManager.unloadPlayer(player.getName());
         player.disconnect(Utilities.colorize(message));
     }
 
-    public static void reloadBans(String sender) {
+    public static void reloadBans(String sender)
+    {
         PlayerManager.getPlayer(sender).sendMessage("Bans Reloaded");
 
         try {
             ConfigManager.bans.reload();
-        } catch (InvalidConfigurationException e) {
+        }
+        catch (InvalidConfigurationException e) {
             e.printStackTrace();
         }
     }
 
-    public static void tempBanPlayer(String sender, String player, int seconds, String message) {
+    public static void tempBanPlayer(String sender, String player, int seconds, String message)
+    {
         GSPlayer p = PlayerManager.getPlayer(sender);
         GSPlayer t = PlayerManager.getSimilarPlayer(player);
 
         if (t == null) {
-            p.sendMessage(ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
-            return;
+            p.sendMessage(ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING);
+//            return;
+        }
+        else {
+            player = t.getName();
         }
 
-        if (DatabaseManager.bans.isPlayerBanned(t.getName()) || DatabaseManager.bans.isPlayerBanned(DatabaseManager.players.getPlayerIP(t.getName()))) {
+        if (DatabaseManager.bans.isPlayerBanned(player)) {
             p.sendMessage(ConfigManager.messages.PLAYER_ALREADY_BANNED);
             return;
         }
@@ -196,21 +260,22 @@ public class BansManager {
         String time = sdf.format(sqlToday);
         sdf.applyPattern("yyyy-MM-dd HH:mm:ss");
 
-        DatabaseManager.bans.tempBanPlayer(player, sender, player, message, sdf.format(sqlToday));
+        DatabaseManager.bans.tempBanPlayer(player, sender, (t != null ? t.getUuid() : null), message, sdf.format(sqlToday));
 
-
-        if(t.getProxiedPlayer() != null) {
+        if (t != null && t.getProxiedPlayer() != null) {
             disconnectPlayer(t.getProxiedPlayer(), ConfigManager.messages.TEMP_BAN_MESSAGE.replace("{sender}", p.getName()).replace("{time}", time).replace("{message}", message));
         }
 
         if (ConfigManager.bans.BroadcastBans) {
             PlayerManager.sendBroadcast(ConfigManager.messages.TEMP_BAN_BROADCAST.replace("{player}", player).replace("{sender}", p.getName()).replace("{message}", message).replace("{time}", time));
-        } else {
+        }
+        else {
             p.sendMessage(ConfigManager.messages.TEMP_BAN_BROADCAST.replace("{player}", player).replace("{sender}", p.getName()).replace("{message}", message).replace("{time}", time));
         }
     }
 
-    public static boolean checkTempBan(Ban b) {
+    public static boolean checkTempBan(Ban b)
+    {
         java.util.Date today = new java.util.Date(Calendar.getInstance().getTimeInMillis());
         java.util.Date banned = b.getBannedUntil();
         if (today.compareTo(banned) >= 0) {

--- a/src/main/java/net/cubespace/geSuit/managers/BansManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/BansManager.java
@@ -9,6 +9,7 @@ import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.objects.Ban;
 import net.cubespace.geSuit.objects.GSPlayer;
 import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
@@ -21,27 +22,16 @@ public class BansManager
         GSPlayer t = PlayerManager.getSimilarPlayer(player);
 
         if (DatabaseManager.bans.isPlayerBanned(player)) {
-            if (p == null) {
-                ProxyServer.getInstance().getConsole().sendMessage(Utilities.colorize(ConfigManager.messages.PLAYER_ALREADY_BANNED));
-            }
-            else {
-                p.sendMessage(ConfigManager.messages.PLAYER_ALREADY_BANNED);
-            }
+            PlayerManager.sendMessageToTarget(p == null ? ProxyServer.getInstance().getConsole() : (CommandSender) p, ConfigManager.messages.NO_SELECTION_MADE);
             return;
         }
 
         if (t == null) {
-            if (p == null) {
-                ProxyServer.getInstance().getConsole().sendMessage(Utilities.colorize(ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING));
-            }
-            else {
-                p.sendMessage(ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING);
-            }
+            PlayerManager.sendMessageToTarget(p == null ? ProxyServer.getInstance().getConsole() : (CommandSender) p, ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING);
         }
 
         if (reason == null || reason.equals("")) {
-            //Even there we colorize. After all it's colored on the ban screen
-            reason = Utilities.colorize(ConfigManager.messages.DEFAULT_BAN_REASON);
+            reason = ConfigManager.messages.DEFAULT_BAN_REASON;
         }
 
         int id = DatabaseManager.bans.banPlayer(player, (t != null && t.getUuid() != null) ? t.getUuid() : null, null, bannedBy, reason, "ban");
@@ -53,15 +43,10 @@ public class BansManager
         }
 
         if (ConfigManager.bans.BroadcastBans) {
-            PlayerManager.sendBroadcast(Utilities.colorize(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy)));
+            PlayerManager.sendBroadcast(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
         }
         else {
-            if (p == null) {
-                ProxyServer.getInstance().getConsole().sendMessage(Utilities.colorize(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy)));
-            }
-            else {
-                p.sendMessage(ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
-            }
+            PlayerManager.sendMessageToTarget(p == null ? ProxyServer.getInstance().getConsole() : (CommandSender) p, ConfigManager.messages.BAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
         }
 
     }
@@ -69,12 +54,12 @@ public class BansManager
     public static void unbanPlayer(String sender, String player)
     {
 //        if (!Utilities.isIPAddress(player) && !DatabaseManager.players.playerExists(player)) {
-//            PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
+//            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
 //            return;
 //        }
 
         if (!DatabaseManager.bans.isPlayerBanned(player, player, player)) {
-            PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_NOT_BANNED);
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.PLAYER_NOT_BANNED);
             return;
         }
 
@@ -86,7 +71,7 @@ public class BansManager
             PlayerManager.sendBroadcast(ConfigManager.messages.PLAYER_UNBANNED.replace("{player}", b.getPlayer()).replace("{sender}", sender));
         }
         else {
-            PlayerManager.sendMessageToPlayer(sender, ConfigManager.messages.PLAYER_UNBANNED.replace("{player}", b.getPlayer()).replace("{sender}", sender));
+            PlayerManager.sendMessageToTarget(sender, ConfigManager.messages.PLAYER_UNBANNED.replace("{player}", b.getPlayer()).replace("{sender}", sender));
         }
     }
 
@@ -105,7 +90,7 @@ public class BansManager
         }
 
         if (ip == null) {
-            PlayerManager.sendMessageToPlayer(bannedBy, ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
+            PlayerManager.sendMessageToTarget(bannedBy, ConfigManager.messages.PLAYER_DOES_NOT_EXIST);
             return;
         }
 
@@ -123,7 +108,7 @@ public class BansManager
             PlayerManager.sendBroadcast(ConfigManager.messages.IPBAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
         }
         else {
-            PlayerManager.sendMessageToPlayer(bannedBy, ConfigManager.messages.IPBAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
+            PlayerManager.sendMessageToTarget(bannedBy, ConfigManager.messages.IPBAN_PLAYER_BROADCAST.replace("{player}", player).replace("{message}", reason).replace("{sender}", bannedBy));
         }
     }
 
@@ -146,26 +131,26 @@ public class BansManager
         Ban b = DatabaseManager.bans.getBanInfo(player);
 
         if (b == null) {
-            p.sendMessage(ConfigManager.messages.PLAYER_NOT_BANNED);
+            PlayerManager.sendMessageToTarget(p, ConfigManager.messages.PLAYER_NOT_BANNED);
         }
         else {
             SimpleDateFormat sdf = new SimpleDateFormat();
             sdf.applyPattern("dd MMM yyyy HH:mm:ss z");
-            p.sendMessage(ChatColor.DARK_AQUA + "--------" + ChatColor.DARK_RED + "Ban Info" + ChatColor.DARK_AQUA + "--------");
-            p.sendMessage(ChatColor.RED + "Player: " + ChatColor.AQUA + b.getPlayer());
+            PlayerManager.sendMessageToTarget(p, ChatColor.DARK_AQUA + "--------" + ChatColor.DARK_RED + "Ban Info" + ChatColor.DARK_AQUA + "--------");
+            PlayerManager.sendMessageToTarget(p, ChatColor.RED + "Player: " + ChatColor.AQUA + b.getPlayer());
             if (b.getUuid() != null) {
-                p.sendMessage(ChatColor.RED + "UUID: " + ChatColor.AQUA + b.getUuid());
+                PlayerManager.sendMessageToTarget(p, ChatColor.RED + "UUID: " + ChatColor.AQUA + b.getUuid());
             }
-            p.sendMessage(ChatColor.RED + "Ban type: " + ChatColor.AQUA + b.getType());
-            p.sendMessage(ChatColor.RED + "Banned by: " + ChatColor.AQUA + b.getBannedBy());
-            p.sendMessage(ChatColor.RED + "Ban reason: " + ChatColor.AQUA + b.getReason());
-            p.sendMessage(ChatColor.RED + "Bannned on: " + ChatColor.AQUA + sdf.format(b.getBannedOn()));
+            PlayerManager.sendMessageToTarget(p, ChatColor.RED + "Ban type: " + ChatColor.AQUA + b.getType());
+            PlayerManager.sendMessageToTarget(p, ChatColor.RED + "Banned by: " + ChatColor.AQUA + b.getBannedBy());
+            PlayerManager.sendMessageToTarget(p, ChatColor.RED + "Ban reason: " + ChatColor.AQUA + b.getReason());
+            PlayerManager.sendMessageToTarget(p, ChatColor.RED + "Bannned on: " + ChatColor.AQUA + sdf.format(b.getBannedOn()));
 
             if (b.getBannedUntil() == null) {
-                p.sendMessage(ChatColor.RED + "Bannned until: " + ChatColor.AQUA + "-Forever-");
+                PlayerManager.sendMessageToTarget(p, ChatColor.RED + "Bannned until: " + ChatColor.AQUA + "-Forever-");
             }
             else {
-                p.sendMessage(ChatColor.RED + "Bannned until: " + ChatColor.AQUA + sdf.format(b.getBannedUntil()));
+                PlayerManager.sendMessageToTarget(p, ChatColor.RED + "Bannned until: " + ChatColor.AQUA + sdf.format(b.getBannedUntil()));
             }
         }
     }
@@ -176,22 +161,22 @@ public class BansManager
         List<Ban> bans = DatabaseManager.bans.getBanHistory(player);
 
         if (bans == null || bans.isEmpty()) {
-            p.sendMessage(Utilities.colorize(ConfigManager.messages.PLAYER_NEVER_BANNED.replace("{player}", player)));
+            PlayerManager.sendMessageToTarget(p, Utilities.colorize(ConfigManager.messages.PLAYER_NEVER_BANNED.replace("{player}", player)));
             return;
         }
-        p.sendMessage(ChatColor.DARK_AQUA + "--------" + ChatColor.DARK_RED + player + "'s Ban History" + ChatColor.DARK_AQUA + "--------");
+        PlayerManager.sendMessageToTarget(p, ChatColor.DARK_AQUA + "--------" + ChatColor.DARK_RED + player + "'s Ban History" + ChatColor.DARK_AQUA + "--------");
         boolean first = true;
         for (Ban b : bans) {
             if (first) {
                 first = false;
             }
             else {
-                p.sendMessage("");
+                PlayerManager.sendMessageToTarget(p, "");
             }
             SimpleDateFormat sdf = new SimpleDateFormat();
             sdf.applyPattern("dd MMM yyyy HH:mm");
-            p.sendMessage((b.getBannedUntil() != null ? ChatColor.GOLD + "| " : ChatColor.RED + "| ") + "Date: " + ChatColor.AQUA + sdf.format(b.getBannedOn()) + ChatColor.RED + (b.getBannedUntil() != null ? ChatColor.DARK_AQUA + " > " + sdf.format(b.getBannedUntil()) : ChatColor.DARK_AQUA + " > forever"));
-            p.sendMessage((b.getBannedUntil() != null ? ChatColor.GOLD + "| " : ChatColor.RED + "| ") + "Banned by " + ChatColor.AQUA + b.getBannedBy() + ChatColor.DARK_AQUA + " (" + ChatColor.GRAY + b.getReason() + ChatColor.DARK_AQUA + ")");
+            PlayerManager.sendMessageToTarget(p, (b.getBannedUntil() != null ? ChatColor.GOLD + "| " : ChatColor.RED + "| ") + "Date: " + ChatColor.AQUA + sdf.format(b.getBannedOn()) + ChatColor.RED + (b.getBannedUntil() != null ? ChatColor.DARK_AQUA + " > " + sdf.format(b.getBannedUntil()) : ChatColor.DARK_AQUA + " > forever"));
+            PlayerManager.sendMessageToTarget(p, (b.getBannedUntil() != null ? ChatColor.GOLD + "| " : ChatColor.RED + "| ") + "Banned by " + ChatColor.AQUA + b.getBannedBy() + ChatColor.DARK_AQUA + " (" + ChatColor.GRAY + b.getReason() + ChatColor.DARK_AQUA + ")");
         }
     }
 
@@ -204,7 +189,7 @@ public class BansManager
         GSPlayer p = PlayerManager.getPlayer(sender);
         GSPlayer t = PlayerManager.getPlayer(player);
         if (t == null) {
-            p.sendMessage(ConfigManager.messages.PLAYER_NOT_ONLINE);
+            PlayerManager.sendMessageToTarget(p, ConfigManager.messages.PLAYER_NOT_ONLINE);
             return;
         }
 
@@ -222,7 +207,7 @@ public class BansManager
 
     public static void reloadBans(String sender)
     {
-        PlayerManager.getPlayer(sender).sendMessage("Bans Reloaded");
+        PlayerManager.sendMessageToTarget(sender, "Bans Reloaded");
 
         try {
             ConfigManager.bans.reload();
@@ -238,7 +223,7 @@ public class BansManager
         GSPlayer t = PlayerManager.getSimilarPlayer(player);
 
         if (t == null) {
-            p.sendMessage(ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING);
+            PlayerManager.sendMessageToTarget(p, ConfigManager.messages.UNKNOWN_PLAYER_STILL_BANNING);
 //            return;
         }
         else {
@@ -246,7 +231,7 @@ public class BansManager
         }
 
         if (DatabaseManager.bans.isPlayerBanned(player)) {
-            p.sendMessage(ConfigManager.messages.PLAYER_ALREADY_BANNED);
+            PlayerManager.sendMessageToTarget(p, ConfigManager.messages.PLAYER_ALREADY_BANNED);
             return;
         }
 
@@ -270,7 +255,7 @@ public class BansManager
             PlayerManager.sendBroadcast(ConfigManager.messages.TEMP_BAN_BROADCAST.replace("{player}", player).replace("{sender}", p.getName()).replace("{message}", message).replace("{time}", time));
         }
         else {
-            p.sendMessage(ConfigManager.messages.TEMP_BAN_BROADCAST.replace("{player}", player).replace("{sender}", p.getName()).replace("{message}", message).replace("{time}", time));
+            PlayerManager.sendMessageToTarget(p, ConfigManager.messages.TEMP_BAN_BROADCAST.replace("{player}", player).replace("{sender}", p.getName()).replace("{message}", message).replace("{time}", time));
         }
     }
 

--- a/src/main/java/net/cubespace/geSuit/managers/HomesManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/HomesManager.java
@@ -1,14 +1,13 @@
 package net.cubespace.geSuit.managers;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.objects.GSPlayer;
 import net.cubespace.geSuit.objects.Home;
 import net.cubespace.geSuit.objects.Location;
 import net.cubespace.geSuit.pluginmessages.TeleportToLocation;
 import net.md_5.bungee.api.ChatColor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class HomesManager {
     public static void createNewHome(GSPlayer player, int serverLimit, int globalLimit, String home, Location loc) {
@@ -17,12 +16,12 @@ public class HomesManager {
             int serverHomeCount = getPlayersServerHomeCount(player);
 
             if (globalHomeCount >= globalLimit) {
-                player.sendMessage(ConfigManager.messages.NO_HOMES_ALLOWED_GLOBAL);
+                PlayerManager.sendMessageToTarget(player, ConfigManager.messages.NO_HOMES_ALLOWED_GLOBAL);
                 return;
             }
 
             if (serverHomeCount >= serverLimit) {
-                player.sendMessage(ConfigManager.messages.NO_HOMES_ALLOWED_SERVER);
+                PlayerManager.sendMessageToTarget(player, ConfigManager.messages.NO_HOMES_ALLOWED_SERVER);
                 return;
             }
 
@@ -34,13 +33,13 @@ public class HomesManager {
             player.getHomes().get(player.getServer()).add(homeObject);
             DatabaseManager.homes.addHome(homeObject);
 
-            player.sendMessage(ConfigManager.messages.HOME_SET);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.HOME_SET);
         } else {
             Home home1 = getHome(player, home);
             home1.setLoc(loc);
             DatabaseManager.homes.updateHome(home1);
 
-            player.sendMessage(ConfigManager.messages.HOME_UPDATED);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.HOME_UPDATED);
         }
     }
 
@@ -66,7 +65,7 @@ public class HomesManager {
 
     public static void listPlayersHomes(GSPlayer player) {
         if (player.getHomes().isEmpty()) {
-            player.sendMessage(ConfigManager.messages.NO_HOMES);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.NO_HOMES);
             return;
         }
 
@@ -86,11 +85,11 @@ public class HomesManager {
             }
 
             if (empty) {
-                player.sendMessage(ConfigManager.messages.NO_HOMES);
+                PlayerManager.sendMessageToTarget(player, ConfigManager.messages.NO_HOMES);
                 return;
             }
 
-            player.sendMessage(homes.substring(0, homes.length() - 2));
+            PlayerManager.sendMessageToTarget(player, homes.substring(0, homes.length() - 2));
         }
 
     }
@@ -125,13 +124,13 @@ public class HomesManager {
     public static void sendPlayerToHome(GSPlayer player, String home) {
         Home h = getHome(player, home);
         if (h == null) {
-            player.sendMessage(ConfigManager.messages.HOME_DOES_NOT_EXIST);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.HOME_DOES_NOT_EXIST);
             return;
         }
 
         TeleportToLocation.execute(player, h.loc);
 
-        player.sendMessage(ConfigManager.messages.SENT_HOME);
+        PlayerManager.sendMessageToTarget(player, ConfigManager.messages.SENT_HOME);
     }
 
     public static void deleteHome(String player, String home) {
@@ -139,7 +138,7 @@ public class HomesManager {
         Home h = getHome(p, home);
 
         if (h == null) {
-            p.sendMessage(ConfigManager.messages.HOME_DOES_NOT_EXIST);
+            PlayerManager.sendMessageToTarget(p, ConfigManager.messages.HOME_DOES_NOT_EXIST);
             return;
         }
 
@@ -152,7 +151,7 @@ public class HomesManager {
 
         DatabaseManager.homes.deleteHome(h);
 
-        p.sendMessage(ConfigManager.messages.HOME_DELETED);
+        PlayerManager.sendMessageToTarget(p, ConfigManager.messages.HOME_DELETED);
     }
 }
 

--- a/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.Utilities;
+import net.cubespace.geSuit.events.NewPlayerJoinEvent;
 import net.cubespace.geSuit.geSuit;
 import net.cubespace.geSuit.objects.GSPlayer;
 import net.md_5.bungee.api.CommandSender;
@@ -40,7 +41,7 @@ public class PlayerManager
 
             GSPlayer gsPlayer = new GSPlayer(player.getName(), (FeatureDetector.canUseUUID()) ? player.getUUID() : null, tps, player.getAddress().getHostString());
             onlinePlayers.put(player.getName(), gsPlayer);
-            
+
             DatabaseManager.players.updatePlayer(gsPlayer);
 
             LoggingManager.log(ConfigManager.messages.PLAYER_LOAD.replace("{player}", gsPlayer.getName()));
@@ -60,7 +61,13 @@ public class PlayerManager
         DatabaseManager.players.insertPlayer(gsPlayer, ip.substring(1, ip.length()));
 
         if (ConfigManager.main.NewPlayerBroadcast) {
-            sendBroadcast(ConfigManager.messages.NEW_PLAYER_BROADCAST.replace("{player}", player.getName()));
+            String welcomeMsg = null;
+            sendBroadcast(welcomeMsg = ConfigManager.messages.NEW_PLAYER_BROADCAST.replace("{player}", player.getName()));
+            // Firing custom event
+            ProxyServer.getInstance().getPluginManager().callEvent(new NewPlayerJoinEvent(player.getName(), welcomeMsg));
+        }
+        else {
+            ProxyServer.getInstance().getPluginManager().callEvent(new NewPlayerJoinEvent(player.getName(), "No welcome for yOU!!!"));
         }
 
         onlinePlayers.put(player.getName(), gsPlayer);

--- a/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
@@ -1,5 +1,6 @@
 package net.cubespace.geSuit.managers;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,9 +38,9 @@ public class PlayerManager
                 tps = DatabaseManager.players.getPlayerTPS(player.getName());
             }
 
-            GSPlayer gsPlayer = new GSPlayer(player.getName(), (FeatureDetector.canUseUUID()) ? player.getUUID() : null, tps);
+            GSPlayer gsPlayer = new GSPlayer(player.getName(), (FeatureDetector.canUseUUID()) ? player.getUUID() : null, tps, player.getAddress().getHostString());
             onlinePlayers.put(player.getName(), gsPlayer);
-
+            
             DatabaseManager.players.updatePlayer(gsPlayer);
 
             LoggingManager.log(ConfigManager.messages.PLAYER_LOAD.replace("{player}", gsPlayer.getName()));
@@ -103,7 +104,7 @@ public class PlayerManager
             target.sendMessage(line);
         }
     }
-    
+
     public static void sendMessageToTarget(GSPlayer target, String message)
     {
         sendMessageToTarget(target.getProxiedPlayer(), message);
@@ -120,6 +121,32 @@ public class PlayerManager
             sendMessageToTarget(p.getName(), message);
         }
         LoggingManager.log(message);
+    }
+
+    public static String getLastSeeninfos(String player)
+    {
+        SimpleDateFormat sdf = new SimpleDateFormat();
+        sdf.applyPattern("dd MMM yyyy HH:mm");
+        GSPlayer p = getPlayer(player);
+        if (p == null) { //Offline
+            p = DatabaseManager.players.loadPlayer(player);
+            if (p == null) //Unknown player
+            {
+                return ConfigManager.messages.PLAYER_DOES_NOT_EXIST;
+            }
+            else {
+                return ConfigManager.messages.PLAYER_SEEN_OFFLINE
+                        .replace("{player}", p.getName())
+                        .replace("{ip}", p.getIp())
+                        .replace("{seen}", sdf.format(p.getLastOnline()));
+            }
+        }
+        else { //Online
+            return ConfigManager.messages.PLAYER_SEEN_ONLINE
+                    .replace("{player}", p.getName())
+                    .replace("{ip}", p.getIp())
+                    .replace("{server}", p.getServer());
+        }
     }
 
     public static GSPlayer getSimilarPlayer(String player)

--- a/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
@@ -9,6 +9,7 @@ import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.geSuit;
 import net.cubespace.geSuit.objects.GSPlayer;
+import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
@@ -90,27 +91,34 @@ public class PlayerManager
         }
     }
 
-    public static void sendMessageToPlayer(String player, String message)
+    public static void sendMessageToTarget(CommandSender target, String message)
     {
-
-        for (String line : Utilities.colorize(message).split("\n")) {
-            if (getPlayer(player) == null) {
-                ProxyServer.getInstance().getConsole().sendMessage(line);
-            }
-            else {
-                getPlayer(player).sendMessage(line);
-            }
+        // Shouldnt need it. But let's be cautious.
+        if (target == null) {
+            return;
         }
+
+        // Not exactly sure where we use the new line besides in the soon-to-be-removed MOTD...
+        for (String line : Utilities.colorize(message).split("\n")) {
+            target.sendMessage(line);
+        }
+    }
+    
+    public static void sendMessageToTarget(GSPlayer target, String message)
+    {
+        sendMessageToTarget(target.getProxiedPlayer(), message);
+    }
+
+    public static void sendMessageToTarget(String target, String message)
+    {
+        sendMessageToTarget(getPlayer(target) != null ? getPlayer(target).getProxiedPlayer() : ProxyServer.getInstance().getConsole(), message);
     }
 
     public static void sendBroadcast(String message)
     {
         for (ProxiedPlayer p : ProxyServer.getInstance().getPlayers()) {
-            for (String line : message.split("\n")) {
-                p.sendMessage(Utilities.colorize(line));
-            }
+            sendMessageToTarget(p.getName(), message);
         }
-
         LoggingManager.log(message);
     }
 
@@ -160,4 +168,5 @@ public class PlayerManager
     {
         return onlinePlayers.get(player);
     }
+
 }

--- a/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/PlayerManager.java
@@ -1,5 +1,10 @@
 package net.cubespace.geSuit.managers;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import net.cubespace.geSuit.FeatureDetector;
 import net.cubespace.geSuit.Utilities;
 import net.cubespace.geSuit.geSuit;
@@ -7,27 +12,27 @@ import net.cubespace.geSuit.objects.GSPlayer;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
+public class PlayerManager
+{
 
-public class PlayerManager {
     public static HashMap<String, GSPlayer> onlinePlayers = new HashMap<>();
     public static ArrayList<ProxiedPlayer> kickedPlayers = new ArrayList<>();
 
-    public static boolean playerExists(ProxiedPlayer player, boolean uuid) {
-        return getPlayer(player.getName()) != null ||
-                (uuid) ? DatabaseManager.players.playerExists(player.getUUID()) : DatabaseManager.players.playerExists(player.getName());
+    public static boolean playerExists(ProxiedPlayer player, boolean uuid)
+    {
+        return getPlayer(player.getName()) != null
+                || (uuid) ? DatabaseManager.players.playerExists(player.getUUID()) : DatabaseManager.players.playerExists(player.getName());
     }
 
-    public static void loadPlayer(ProxiedPlayer player) {
+    public static void loadPlayer(ProxiedPlayer player)
+    {
         if (playerExists(player, FeatureDetector.canUseUUID())) {
             boolean tps;
 
-            if(FeatureDetector.canUseUUID()) {
+            if (FeatureDetector.canUseUUID()) {
                 tps = DatabaseManager.players.getPlayerTPS(player.getName());
-            } else {
+            }
+            else {
                 tps = DatabaseManager.players.getPlayerTPS(player.getName());
             }
 
@@ -39,12 +44,14 @@ public class PlayerManager {
             LoggingManager.log(ConfigManager.messages.PLAYER_LOAD.replace("{player}", gsPlayer.getName()));
 
             HomesManager.loadPlayersHomes(gsPlayer);
-        } else {
+        }
+        else {
             createNewPlayer(player);
         }
     }
 
-    private static void createNewPlayer(final ProxiedPlayer player) {
+    private static void createNewPlayer(final ProxiedPlayer player)
+    {
         String ip = player.getAddress().getAddress().toString();
         final GSPlayer gsPlayer = new GSPlayer(player.getName(), (FeatureDetector.canUseUUID()) ? player.getUUID() : null, true);
 
@@ -60,10 +67,12 @@ public class PlayerManager {
         if (ConfigManager.spawn.SpawnNewPlayerAtNewspawn && SpawnManager.NewPlayerSpawn != null) {
             SpawnManager.newPlayers.add(player);
 
-            ProxyServer.getInstance().getScheduler().schedule(geSuit.instance, new Runnable() {
+            ProxyServer.getInstance().getScheduler().schedule(geSuit.instance, new Runnable()
+            {
 
                 @Override
-                public void run() {
+                public void run()
+                {
                     SpawnManager.sendPlayerToNewPlayerSpawn(gsPlayer);
                     SpawnManager.newPlayers.remove(player);
                 }
@@ -72,7 +81,8 @@ public class PlayerManager {
         }
     }
 
-    public static void unloadPlayer(String player) {
+    public static void unloadPlayer(String player)
+    {
         if (onlinePlayers.containsKey(player)) {
             onlinePlayers.remove(player);
 
@@ -80,13 +90,21 @@ public class PlayerManager {
         }
     }
 
-    public static void sendMessageToPlayer(String player, String message) {
-        for (String line : message.split("\n")) {
+    public static void sendMessageToPlayer(String player, String message)
+    {
+
+        for (String line : Utilities.colorize(message).split("\n")) {
+            if (getPlayer(player) == null) {
+                ProxyServer.getInstance().getConsole().sendMessage(line);
+            }
+            else {
                 getPlayer(player).sendMessage(line);
+            }
         }
     }
 
-    public static void sendBroadcast(String message) {
+    public static void sendBroadcast(String message)
+    {
         for (ProxiedPlayer p : ProxyServer.getInstance().getPlayers()) {
             for (String line : message.split("\n")) {
                 p.sendMessage(Utilities.colorize(line));
@@ -96,7 +114,8 @@ public class PlayerManager {
         LoggingManager.log(message);
     }
 
-    public static GSPlayer getSimilarPlayer( String player ) {
+    public static GSPlayer getSimilarPlayer(String player)
+    {
         if (player == null) {
             Exception exception = new Exception("test");
             exception.printStackTrace();
@@ -104,8 +123,8 @@ public class PlayerManager {
             return null;
         }
 
-        for ( GSPlayer p : onlinePlayers.values() ) {
-            if ( ( p.getProxiedPlayer() != null && p.getProxiedPlayer().getDisplayName() != null && p.getProxiedPlayer().getDisplayName().toLowerCase().startsWith( player.toLowerCase() ) ) || p.getName().toLowerCase().startsWith( player.toLowerCase() ) || ( p.getUuid() != null && p.getUuid().equals(player) ) ) {
+        for (GSPlayer p : onlinePlayers.values()) {
+            if ((p.getProxiedPlayer() != null && p.getProxiedPlayer().getDisplayName() != null && p.getProxiedPlayer().getDisplayName().toLowerCase().startsWith(player.toLowerCase())) || p.getName().toLowerCase().startsWith(player.toLowerCase()) || (p.getUuid() != null && p.getUuid().equals(player))) {
                 return p;
             }
         }
@@ -113,11 +132,32 @@ public class PlayerManager {
         return null;
     }
 
-    public static Collection<GSPlayer> getPlayers() {
+    public static List<GSPlayer> getPlayersByIP(String ip)
+    {
+        List<GSPlayer> matchingPlayers = new ArrayList<GSPlayer>();
+        if (ip == null) {
+            Exception exception = new Exception("test");
+            exception.printStackTrace();
+            geSuit.instance.getLogger().severe("getPlayersByIP() ip is null");
+            return null;
+        }
+
+        for (GSPlayer p : onlinePlayers.values()) {
+            if (p.getProxiedPlayer().getAddress().getHostString().equalsIgnoreCase(ip)) {
+                matchingPlayers.add(p);
+            }
+        }
+
+        return matchingPlayers;
+    }
+
+    public static Collection<GSPlayer> getPlayers()
+    {
         return onlinePlayers.values();
     }
 
-    public static GSPlayer getPlayer(String player) {
+    public static GSPlayer getPlayer(String player)
+    {
         return onlinePlayers.get(player);
     }
 }

--- a/src/main/java/net/cubespace/geSuit/managers/SpawnManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/SpawnManager.java
@@ -1,5 +1,7 @@
 package net.cubespace.geSuit.managers;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.cubespace.geSuit.objects.GSPlayer;
 import net.cubespace.geSuit.objects.Location;
 import net.cubespace.geSuit.objects.Spawn;
@@ -7,9 +9,6 @@ import net.cubespace.geSuit.pluginmessages.SendSpawn;
 import net.cubespace.geSuit.pluginmessages.TeleportToLocation;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.connection.Server;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class SpawnManager {
     public static Location NewPlayerSpawn;
@@ -32,7 +31,7 @@ public class SpawnManager {
 
     public static void sendPlayerToProxySpawn(GSPlayer player) {
         if (!doesProxySpawnExist()) {
-            player.sendMessage(ConfigManager.messages.SPAWN_DOES_NOT_EXIST);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.SPAWN_DOES_NOT_EXIST);
             return;
         }
 
@@ -42,7 +41,7 @@ public class SpawnManager {
 
     public static void sendPlayerToNewPlayerSpawn(GSPlayer player) {
         if (!doesNewPlayerSpawnExist()) {
-            player.sendMessage(ConfigManager.messages.SPAWN_DOES_NOT_EXIST);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.SPAWN_DOES_NOT_EXIST);
             return;
         }
 
@@ -61,10 +60,10 @@ public class SpawnManager {
     private static void setSpawn(GSPlayer player, Spawn spawn, boolean exists) {
         if (exists) {
             DatabaseManager.spawns.updateSpawn(spawn);
-            player.sendMessage(ConfigManager.messages.SPAWN_UPDATED);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.SPAWN_UPDATED);
         } else {
             DatabaseManager.spawns.insertSpawn(spawn);
-            player.sendMessage(ConfigManager.messages.SPAWN_SET);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.SPAWN_SET);
         }
 
         SendSpawn.execute(spawn);

--- a/src/main/java/net/cubespace/geSuit/managers/TeleportManager.java
+++ b/src/main/java/net/cubespace/geSuit/managers/TeleportManager.java
@@ -1,14 +1,13 @@
 package net.cubespace.geSuit.managers;
 
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 import net.cubespace.geSuit.geSuit;
 import net.cubespace.geSuit.objects.GSPlayer;
 import net.cubespace.geSuit.objects.Location;
 import net.cubespace.geSuit.pluginmessages.TeleportToLocation;
 import net.cubespace.geSuit.pluginmessages.TeleportToPlayer;
 import net.md_5.bungee.api.ProxyServer;
-
-import java.util.HashMap;
-import java.util.concurrent.TimeUnit;
 
 public class TeleportManager {
     public static HashMap<GSPlayer, GSPlayer> pendingTeleportsTPA = new HashMap<>(); // Player ----teleported---> player
@@ -102,33 +101,33 @@ public class TeleportManager {
         if (pendingTeleportsTPA.containsKey(player)) {
             GSPlayer target = pendingTeleportsTPA.get(player);
             target.sendMessage(ConfigManager.messages.TELEPORTED_TO_PLAYER.replace("{player}", player.getName()));
-            player.sendMessage(ConfigManager.messages.PLAYER_TELEPORTED_TO_YOU.replace("{player}", target.getName()));
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.PLAYER_TELEPORTED_TO_YOU.replace("{player}", target.getName()));
             TeleportToPlayer.execute(target, player);
             pendingTeleportsTPA.remove(player);
         } else if (pendingTeleportsTPAHere.containsKey(player)) {
             GSPlayer target = pendingTeleportsTPAHere.get(player);
-            player.sendMessage(ConfigManager.messages.TELEPORTED_TO_PLAYER.replace("{player}", target.getName()));
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.TELEPORTED_TO_PLAYER.replace("{player}", target.getName()));
             target.sendMessage(ConfigManager.messages.PLAYER_TELEPORTED_TO_YOU.replace("{player}", player.getName()));
             TeleportToPlayer.execute(player, target);
             pendingTeleportsTPAHere.remove(player);
         } else {
-            player.sendMessage(ConfigManager.messages.NO_TELEPORTS);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.NO_TELEPORTS);
         }
     }
 
     public static void denyTeleportRequest(GSPlayer player) {
         if (pendingTeleportsTPA.containsKey(player)) {
             GSPlayer target = pendingTeleportsTPA.get(player);
-            player.sendMessage(ConfigManager.messages.TELEPORT_DENIED.replace("{player}", target.getName()));
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.TELEPORT_DENIED.replace("{player}", target.getName()));
             target.sendMessage(ConfigManager.messages.TELEPORT_REQUEST_DENIED.replace("{player}", player.getName()));
             pendingTeleportsTPA.remove(player);
         } else if (pendingTeleportsTPAHere.containsKey(player)) {
             GSPlayer target = pendingTeleportsTPAHere.get(player);
-            player.sendMessage(ConfigManager.messages.TELEPORT_DENIED.replace("{player}", target.getName()));
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.TELEPORT_DENIED.replace("{player}", target.getName()));
             target.sendMessage(ConfigManager.messages.TELEPORT_REQUEST_DENIED.replace("{player}", player.getName()));
             pendingTeleportsTPAHere.remove(player);
         } else {
-            player.sendMessage(ConfigManager.messages.NO_TELEPORTS);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.NO_TELEPORTS);
         }
     }
 
@@ -152,9 +151,9 @@ public class TeleportManager {
 
     public static void sendPlayerToLastBack(GSPlayer player, boolean death, boolean teleport) {
         if (player.hasDeathBackLocation() || player.hasTeleportBackLocation()) {
-            player.sendMessage(ConfigManager.messages.SENT_BACK);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.SENT_BACK);
         } else {
-            player.sendMessage(ConfigManager.messages.NO_BACK_TP);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.NO_BACK_TP);
         }
         if (death && teleport) {
             if (player.hasDeathBackLocation() || player.hasTeleportBackLocation()) {
@@ -170,10 +169,10 @@ public class TeleportManager {
     public static void togglePlayersTeleports(GSPlayer player) {
         if (player.acceptingTeleports()) {
             player.setAcceptingTeleports(false);
-            player.sendMessage(ConfigManager.messages.TELEPORT_TOGGLE_OFF);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.TELEPORT_TOGGLE_OFF);
         } else {
             player.setAcceptingTeleports(true);
-            player.sendMessage(ConfigManager.messages.TELEPORT_TOGGLE_ON);
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.TELEPORT_TOGGLE_ON);
         }
     }
 
@@ -190,7 +189,7 @@ public class TeleportManager {
                 TeleportToPlayer.execute(p, t);
             }
 
-            player.sendMessage(ConfigManager.messages.ALL_PLAYERS_TELEPORTED.replace("{player}", t.getName()));
+            PlayerManager.sendMessageToTarget(player, ConfigManager.messages.ALL_PLAYERS_TELEPORTED.replace("{player}", t.getName()));
         }
     }
 

--- a/src/main/java/net/cubespace/geSuit/objects/Ban.java
+++ b/src/main/java/net/cubespace/geSuit/objects/Ban.java
@@ -6,15 +6,19 @@ import java.util.Date;
 public class Ban {
     private int id;
     private String player;
+    private String uuid;
+    private String ip;
     private String bannedBy;
     private String reason;
     private String type;
     private Date bannedOn;
     private Date bannedUntil;
 
-    public Ban(int id, String player, String bannedBy, String reason, String type, Timestamp timestamp, Timestamp timestamp2) {
+    public Ban(int id, String player, String uuid, String ip, String bannedBy, String reason, String type, Timestamp timestamp, Timestamp timestamp2) {
         this.id = id;
         this.player = player;
+        this.uuid = uuid;
+        this.ip = ip;
         this.bannedBy = bannedBy;
         this.reason = reason;
         this.type = type;
@@ -49,4 +53,20 @@ public class Ban {
     public int getId() {
         return id;
     }
+
+    public String getUuid()
+    {
+        return uuid;
+    }
+
+    public void setUuid(String uuid)
+    {
+        this.uuid = uuid;
+    }
+
+    public String getIp()
+    {
+        return ip;
+    }
+
 }

--- a/src/main/java/net/cubespace/geSuit/objects/GSPlayer.java
+++ b/src/main/java/net/cubespace/geSuit/objects/GSPlayer.java
@@ -1,88 +1,121 @@
 package net.cubespace.geSuit.objects;
 
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
 import net.cubespace.geSuit.Utilities;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+public class GSPlayer
+{
 
-public class GSPlayer {
     private String playername;
     private String uuid;
     private boolean acceptingTeleports;
     private String server = null;
+    private String ip;
+    private Timestamp lastOnline;
 
     private HashMap<String, ArrayList<Home>> homes = new HashMap<>();
     private Location deathBackLocation;
     private Location teleportBackLocation;
     private boolean lastBack;
     private boolean firstConnect = true;
+    
 
-    public GSPlayer(String name, String uuid, boolean tps) {
+    public GSPlayer(String name, String uuid, boolean tps)
+    {
+        this(name, uuid, tps, null);
+    }
+
+    public GSPlayer(String name, String uuid, boolean tps, String ip)
+    {
+        this(name, uuid, tps, ip, null);
+    }
+    
+    public GSPlayer(String name, String uuid, boolean tps, String ip, Timestamp lastOnline)
+    {
+        ProxyServer.getInstance().getLogger().info("LOADED DATA: "+name+" "+uuid+" "+tps+" "+ip+" "+lastOnline);
         this.playername = name;
         this.uuid = uuid;
         this.acceptingTeleports = tps;
+        this.ip = ip;
+        this.lastOnline = lastOnline;
     }
 
-    public String getName() {
+    public String getName()
+    {
         return playername;
     }
 
-    public ProxiedPlayer getProxiedPlayer() {
-        return ProxyServer.getInstance().getPlayer( playername );
+    public ProxiedPlayer getProxiedPlayer()
+    {
+        return ProxyServer.getInstance().getPlayer(playername);
     }
 
-    public void sendMessage( String message ) {
-        for ( String line : message.split( "\n" ) ) {
-            getProxiedPlayer().sendMessage( Utilities.colorize(line) );
+    public void sendMessage(String message)
+    {
+        for (String line : message.split("\n")) {
+            getProxiedPlayer().sendMessage(Utilities.colorize(line));
         }
     }
 
-    public boolean acceptingTeleports() {
+    public boolean acceptingTeleports()
+    {
         return this.acceptingTeleports;
     }
 
-    public void setAcceptingTeleports( boolean tp ) {
+    public void setAcceptingTeleports(boolean tp)
+    {
         this.acceptingTeleports = tp;
     }
 
-    public void setDeathBackLocation( Location loc ) {
+    public void setDeathBackLocation(Location loc)
+    {
         deathBackLocation = loc;
         lastBack = true;
     }
 
-    public boolean hasDeathBackLocation() {
+    public boolean hasDeathBackLocation()
+    {
         return deathBackLocation != null;
     }
 
-    public void setTeleportBackLocation( Location loc ) {
+    public void setTeleportBackLocation(Location loc)
+    {
         teleportBackLocation = loc;
         lastBack = false;
     }
 
-    public Location getLastBackLocation() {
-        if ( lastBack ) {
+    public Location getLastBackLocation()
+    {
+        if (lastBack) {
             return deathBackLocation;
-        } else {
+        }
+        else {
             return teleportBackLocation;
         }
     }
 
-    public boolean hasTeleportBackLocation() {
+    public boolean hasTeleportBackLocation()
+    {
         return teleportBackLocation != null;
     }
 
-    public Location getDeathBackLocation() {
+    public Location getDeathBackLocation()
+    {
         return deathBackLocation;
     }
 
-    public Location getTeleportBackLocation() {
+    public Location getTeleportBackLocation()
+    {
         return teleportBackLocation;
     }
 
-    public String getServer() {
+    public String getServer()
+    {
         if (getProxiedPlayer() == null) {
             return server;
         }
@@ -90,27 +123,43 @@ public class GSPlayer {
         return getProxiedPlayer().getServer().getInfo().getName();
     }
 
-    public HashMap<String, ArrayList<Home>> getHomes() {
+    public HashMap<String, ArrayList<Home>> getHomes()
+    {
         return homes;
     }
 
-    public boolean firstConnect() {
+    public boolean firstConnect()
+    {
         return firstConnect;
     }
 
-    public void connected() {
+    public void connected()
+    {
         firstConnect = false;
     }
 
-    public void connectTo( ServerInfo s ) {
-        getProxiedPlayer().connect( s );
+    public void connectTo(ServerInfo s)
+    {
+        getProxiedPlayer().connect(s);
     }
 
-    public String getUuid() {
+    public String getUuid()
+    {
         return uuid;
     }
 
-    public void setServer(String server) {
+    public void setServer(String server)
+    {
         this.server = server;
+    }
+
+    public String getIp()
+    {
+        return ip;
+    }
+
+    public Timestamp getLastOnline()
+    {
+        return lastOnline;
     }
 }

--- a/src/main/java/net/cubespace/geSuit/tasks/DatabaseUpdateRowUUID.java
+++ b/src/main/java/net/cubespace/geSuit/tasks/DatabaseUpdateRowUUID.java
@@ -1,0 +1,61 @@
+package net.cubespace.geSuit.tasks;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import net.cubespace.geSuit.Utilities;
+import net.cubespace.geSuit.database.ConnectionHandler;
+import net.cubespace.geSuit.managers.DatabaseManager;
+import net.md_5.bungee.api.ProxyServer;
+
+/**
+ *
+ * @author JR
+ */
+public class DatabaseUpdateRowUUID implements Runnable
+{
+
+    int rowID;
+    String playerName;
+
+    public DatabaseUpdateRowUUID(int id, String pname)
+    {
+        rowID = id;
+        playerName = pname;
+    }
+
+    @Override
+    public void run()
+    {
+        if (rowID == -1) {
+            ProxyServer.getInstance().getLogger().warning("Incorrect row " + rowID + " for player " + playerName);
+            return;
+        }
+        String uuid = Utilities.getUUID(playerName);
+        if (uuid == null || uuid.isEmpty()) {
+            ProxyServer.getInstance().getLogger().warning("Could not fetch UUID for player " + playerName);
+        }
+        else {
+            ConnectionHandler connectionHandler = null;
+            try {
+                connectionHandler = DatabaseManager.connectionPool.getConnection();
+                PreparedStatement updateUUID = connectionHandler.getPreparedStatement("updateRowUUID");
+                updateUUID.setString(1, uuid);
+                updateUUID.setInt(2, rowID);
+                updateUUID.executeUpdate();
+            }
+            catch (SQLException ex) {
+                ProxyServer.getInstance().getLogger().warning("Error while updating db for player " + playerName + " with UUID " + uuid);
+                Logger.getLogger(DatabaseUpdateRowUUID.class.getName()).log(Level.SEVERE, null, ex);
+            }
+            finally {
+                if (connectionHandler != null) {
+                    connectionHandler.release();
+                }
+            }
+
+        }
+    }
+
+}

--- a/src/main/java/net/cubespace/geSuit/tasks/GlobalAnnouncements.java
+++ b/src/main/java/net/cubespace/geSuit/tasks/GlobalAnnouncements.java
@@ -1,40 +1,44 @@
 package net.cubespace.geSuit.tasks;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import net.cubespace.geSuit.Utilities;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-import java.util.ArrayList;
-import java.util.Collection;
+public class GlobalAnnouncements implements Runnable
+{
 
-public class GlobalAnnouncements implements Runnable  {
-	private ArrayList<String> list = new ArrayList<>();
-	private int count = 0;
+    private ArrayList<String> list = new ArrayList<>();
+    private int count = 0;
 
-	public void addAnnouncement(String message) {
-		list.add(Utilities.colorize(message));
-	}
+    public void addAnnouncement(String message)
+    {
+        list.add(Utilities.colorize(message));
+    }
 
-	public void run() {
-		if (list.isEmpty()) {
-			return;
-		}
+    public void run()
+    {
+        if (list.isEmpty()) {
+            return;
+        }
 
-		Collection<ProxiedPlayer> players = ProxyServer.getInstance().getPlayers();
-		if (players.isEmpty()) {
-			return;
-		}
-
-		for(ProxiedPlayer player: players){
-            for ( String line : list.get(count).split( "\n" ) ) {
-            	player.sendMessage(line);
+        Collection<ProxiedPlayer> players = ProxyServer.getInstance().getPlayers();
+        if (players.isEmpty()) {
+            return;
+        }
+        
+        for (ProxiedPlayer player : players) {
+            for (String line : list.get(count).split("\n")) {
+                // not sure if everything is thread safe. In doubt, leaving that one. It's colorized anyway.
+                player.sendMessage(line);
             }
-		}
+        }
 
-		count++;
+        count++;
 
-		if ((count+1) > list.size()){
-			count = 0;
-		}
-	}
+        if ((count + 1) > list.size()) {
+            count = 0;
+        }
+    }
 }

--- a/src/main/java/net/cubespace/geSuit/tasks/ServerAnnouncements.java
+++ b/src/main/java/net/cubespace/geSuit/tasks/ServerAnnouncements.java
@@ -1,40 +1,44 @@
 package net.cubespace.geSuit.tasks;
 
+import java.util.ArrayList;
 import net.cubespace.geSuit.Utilities;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
-import java.util.ArrayList;
+public class ServerAnnouncements implements Runnable
+{
 
-public class ServerAnnouncements implements Runnable {
+    ArrayList<String> list = new ArrayList<String>();
+    int count = 0;
+    ServerInfo server;
 
-	ArrayList<String> list = new ArrayList<String>();
-	int count = 0;
-	ServerInfo server;
+    public ServerAnnouncements(ServerInfo server)
+    {
+        this.server = server;
+    }
 
-	public ServerAnnouncements(ServerInfo server) {
-		this.server = server;
-	}
+    public void addAnnouncement(String message)
+    {
+        list.add(Utilities.colorize(message));
+    }
 
-	public void addAnnouncement(String message) {
-		list.add(Utilities.colorize(message));
-	}
-
-	public void run() {
-		if (list.isEmpty()) {
-			return;
-		}
-		if (server.getPlayers().isEmpty()) {
-			return;
-		}
-		for(ProxiedPlayer player: server.getPlayers()){
-            for ( String line : list.get(count).split( "\n" ) ) {
-            	player.sendMessage(line);
+    public void run()
+    {
+        if (list.isEmpty()) {
+            return;
+        }
+        if (server.getPlayers().isEmpty()) {
+            return;
+        }
+        for (ProxiedPlayer player : server.getPlayers()) {
+            for (String line : list.get(count).split("\n")) {
+                // not sure if everything is thread safe. In doubt, leaving that one. It's colorized anyway.
+                player.sendMessage(line);
             }
-		}
-		count++;
-		if((count+1)>list.size()){
-			count=0;
-		}
-	}
+        }
+        count++;
+        if ((count + 1) > list.size()) {
+            count = 0;
+        }
+    }
 }


### PR DESCRIPTION
Small things:
- Fixed some minor color in feedback messages
- Added 2 new bungee console commands that could save your life one day: !ban <player|ip> !unban <player|ip|uuid>
- Added a new parser for the tempban time parameter
- Added a new command: /banhistory <lookup> -> Matches player, ip or uuid (exact only)
- Added a shortcut to start a task that update a ban UUID

Large changes:
- Migrated database to Bans v3
- Instead of a single lookup field (was mutable tho), we now have 3: name, uuid, ip. The point is to have some lattitude. Being able to ban by name, and then, on it's own, improve it by adding the UUID is much better. Remember kids, KISS: Keep it simple and stupid.
- The game will now accept any player name to be banned. it will attempt to retreive a UUID attached to that name if the player is not known.
- tempban is now completly fixed.
- Ban by ip now also kick the players that are on said IP
- All around bug fixes and trying to make this plugin usable.
